### PR TITLE
KIWI-1320: Github Migrations - Post cleanup for CIC Front

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
 # This is the CODEOWNERS file. These owners will be the default owners for everything in the di-ipv-cri-cic-front repository
 # The following below will be requested for review when someone opens a pull request.
 
-* @alphagov/di-ipv-kiwi-front-codeowners
+* @govuk-one-login/kiwi-front-codeowners
 
 # The following allows QA to review changes to /tests directory
 
-tests/ @alphagov/di-ipv-kiwi-qa-codeowners @alphagov/di-ipv-kiwi-front-codeowners
+tests/ @govuk-one-login/kiwi-qa-codeowners @govuk-one-login/kiwi-front-codeowners

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -15,7 +15,7 @@
 <!-- List any related ADRs or RFCs -->
 <!-- Delete/copy as appropriate -->
 
-- [F2F-XXXX](https://govukverify.atlassian.net/browse/F2F-XXX)
+- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXX)
 
 ## Checklists
 

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Proposed changes
 <!-- Provide a general summary of your changes in the Title above -->
-<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXXX] PR Title` -->
+<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->
 
 ### What changed
 
@@ -15,7 +15,7 @@
 <!-- List any related ADRs or RFCs -->
 <!-- Delete/copy as appropriate -->
 
-- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXX)
+- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXXX)
 
 ## Checklists
 


### PR DESCRIPTION
- Add the CODEOWNERS for new govuk-one-login github CIC Front

- [F2F-1320](https://govukverify.atlassian.net/browse/F2F-1320)
