### PR TITLE
[KIWI-1340] - Redirecting with server_error for Users not from IPV Core

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -6,6 +6,7 @@ const session = require("express-session");
 const AWS = require("aws-sdk");
 const DynamoDBStore = require("connect-dynamodb")(session);
 const wizard = require('hmpo-form-wizard');
+const logger = require("hmpo-logger")
 
 const commonExpress = require("di-ipv-cri-common-express");
 
@@ -132,4 +133,13 @@ const wizardOptions = {
 
 router.use(wizard(steps, fields, wizardOptions));
 
-router.use(commonExpress.lib.errorHandling.redirectAsErrorToCallback);
+router.use((err, req, res, next) => {
+  logger.get().error("Error caught by Express handler - redirecting to Callback with server_error", {err});
+	const REDIRECT_URI = req.session?.authParams?.redirect_uri;
+	if (REDIRECT_URI) {
+		next(err);
+		router.use(commonExpress.lib.errorHandling.redirectAsErrorToCallback);
+	} else {
+		res.redirect("/error")
+	}
+});

--- a/src/app/cic/steps.js
+++ b/src/app/cic/steps.js
@@ -35,5 +35,8 @@ module.exports = {
     noPost: true,
     next: "/oauth2/callback",
   },
+	"/error": {
+    entryPoint: true,
+  }
 
 };

--- a/src/views/cic/error.html
+++ b/src/views/cic/error.html
@@ -1,0 +1,2 @@
+<!-- Found in common folder -->
+{% extends "unrecoverable-error.njk" %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -6921,6 +6921,11 @@ uuid@^8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
+
 v8-to-istanbul@^9.0.1:
   version "9.1.0"
   resolved "https://registry.yarnpkg.com/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz#1b83ed4e397f58c85c266a570fc2558b5feb9265"


### PR DESCRIPTION
### What changed
Adds check for redirect_uri before performing a callback() to IPVCore, if redirect_uri is not present then an internal F2F Error page is shown allowing the user to navigate back to Gov.uk and begin their journey again

### Issue tracking
https://govukverify.atlassian.net/browse/KIWI-1297

**Before Fix**
<img width="988" alt="image" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/13416125/b4845508-2191-44e7-8731-8158e5286b5a">

<img width="1671" alt="image" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/13416125/4d365a15-6ed5-4f59-8e7a-b51d2a5add8a">

**After Fix**
<img width="976" alt="image" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/13416125/b299a202-3abf-4494-be41-6ca86d107301">

<img width="1671" alt="image" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/13416125/cec0964e-624d-42a5-979d-cfab1cb6fd74">
