### PR TITLE
[KIWI-1170] - Update Copy to Fix Page Title Errors

### DIFF
--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -1,17 +1,4 @@
 # title is managed in default.yml
-            
-landingPage:
-  pageTitle: "Prove your identity in person"
-  title: "Proving your identity in person"
-  body: "What you need to do"
-  instructions:
-    steps:
-      one: "Complete an online form to provide your basic personal details and select a photo ID you can take to a Post Office. We will then send you a confirmation email."
-      two: "Take the confirmation email and your photo ID to a Post Office."
-      three: "A member of Post Office staff will process your photo ID and take a photo of your face to verify your identity."
-  dataInfo:
-    title: "What happens after the Post Office"
-    body: "Once your identity has been proven, you must return online to your GOV.UK account to access the service you need."
 
 nameEntry:
   title: "Rhowch eich enw yn union fel y mae'n ymddangos ar eich ID gyda llun"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -57,7 +57,7 @@ error:
     subTitle: We cannot prove your identity right now.
     subHeading: What can you do
     description: Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
-    contactMeLink: Contact the GOV.UK account team (opens in a new tab)
+    contactMeLink: Contact the GOV.UK One Login team (opens in a new tab)
     buttonText: Go to the GOV.UK homepage
     buttonLink: https://www.gov.uk/
 

--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -4,7 +4,7 @@ error:
     subTitle: We cannot prove your identity right now.
     subHeading: What can you do
     description: Go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
-    contactMeLink: Contact the GOV.UK account team (opens in a new tab)
+    contactMeLink: Contact the GOV.UK One Login team (opens in a new tab)
     buttonText: Go to the GOV.UK homepage
     buttonLink: https://www.gov.uk/
 
@@ -16,7 +16,7 @@ pageNotFound:
     - If you pasted the web address, check you copied the entire address.
     - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Go to the GOV.UK homepage</a>
-    - <a href="https://signin.account.gov.uk/contact-us" target="_blank" class="govuk-link">Contact the GOV.UK account team (opens in a new tab)</a>
+    - <a href="https://signin.account.gov.uk/contact-us" target="_blank" class="govuk-link">Contact the GOV.UK One Login team (opens in a new tab)</a>
 
 
 sessionEnded:

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -1,18 +1,5 @@
 # title is managed in default.yml
             
-landingPage:
-  pageTitle: "Prove your identity in person"
-  title: "Proving your identity in person"
-  body: "What you need to do"
-  instructions:
-    steps:
-      one: "Complete an online form to provide your basic personal details and select a photo ID you can take to a Post Office. We will then send you a confirmation email."
-      two: "Take the confirmation email and your photo ID to a Post Office."
-      three: "A member of Post Office staff will process your photo ID and take a photo of your face to verify your identity."
-  dataInfo:
-    title: "What happens after the Post Office"
-    body: "Once your identity has been proven, you must return online to your GOV.UK account to access the service you need."
-
 nameEntry:
   title: "Enter your name exactly as it appears on your photo ID"
   surname: "Last name"


### PR DESCRIPTION
### What changed

Any references to “[GOV.UK](http://gov.uk/) account” should be replaced with “[GOV.UK](http://gov.uk/) One Login”

The page with title Prove your identity in person is no longer required and should be removed. It has likely been superseded by the [landing page](https://www.figma.com/file/tK7chtvE4bSaWSmBU7zcLV/F2F-Flow---Screen-Iterations?type=design&node-id=6171-286110&mode=design&t=wHeTOuF0PbHMRKy3-4) that is now part of the F2F CRI

https://govukverify.atlassian.net/browse/KIWI-1170

<img width="745" alt="image" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/13416125/964fe7a6-2567-41dc-b0f8-117a9f224dff">

