### PR TITLE
[KIWI-1152] Updates support link

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -32,7 +32,7 @@ govuk:
     cookieLinkText: "Darganfyddwch fwy am gwcis"
   phaseBanner:
     tag: beta
-    content: Mae hwn yn wasanaeth newydd – bydd eich <a href=\"https://signin.account.gov.uk/contact-us\" target=\"_blank\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella.
+    content: Mae hwn yn wasanaeth newydd – bydd eich <a href=\"https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id\" target=\"_blank\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella.
   footerNavItems:
     meta:
       items:
@@ -44,7 +44,7 @@ govuk:
           text: Telerau ac amodau
         - href: https://signin.account.gov.uk/privacy-notice
           text: Hysbysiad preifatrwydd
-        - href: https://signin.account.gov.uk/contact-us
+        - href: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id
           text: Cymorth
   copyright:
     text: "© Hawlfraint y Goron"

--- a/src/locales/cy/pages.errors.yml
+++ b/src/locales/cy/pages.errors.yml
@@ -16,7 +16,7 @@ pageNotFound:
     - Os ydych wedi gludo'r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo'r cyfeiriad cyfan.",
     - Gallwch hefyd fynd yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.",
     - <a href=\"https://www.gov.uk/\" class=\"govuk-button\" data-module=\"govuk-button\">Ewch i hafan GOV.UK</a>",
-    - <a href=\"https://signin.account.gov.uk/contact-us\" target=\"_blank\" class=\"govuk-link\">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>"
+    - <a href=\"https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id\" target=\"_blank\" class=\"govuk-link\">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>"
 
 
 sessionEnded:

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -32,7 +32,7 @@ govuk:
     cookieLinkText: "Find out more about cookies"
   phaseBanner:
     tag: beta
-    content: This is a new service – your <a href="https://signin.account.gov.uk/contact-us" target="_blank" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
+    content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id" target="_blank" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
   footerNavItems:
     meta:
       items:
@@ -44,7 +44,7 @@ govuk:
           text: Terms and conditions
         - href: https://signin.account.gov.uk/privacy-notice
           text: Privacy notice
-        - href: https://signin.account.gov.uk/contact-us
+        - href: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id
           text: Support
   copyright:
     text: "© Crown copyright"

--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -16,7 +16,7 @@ pageNotFound:
     - If you pasted the web address, check you copied the entire address.
     - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Go to the GOV.UK homepage</a>
-    - <a href="https://signin.account.gov.uk/contact-us" target="_blank" class="govuk-link">Contact the GOV.UK One Login team (opens in a new tab)</a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id" target="_blank" class="govuk-link">Contact the GOV.UK One Login team (opens in a new tab)</a>
 
 
 sessionEnded:

--- a/src/views/cic/error.html
+++ b/src/views/cic/error.html
@@ -1,2 +1,1 @@
-<!-- Found in common folder -->
-{% extends "unrecoverable-error.njk" %}
+{% include "errors/error.html" %}

--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -1,2 +1,28 @@
-<!-- Found in common folder -->
-{% extends "unrecoverable-error.njk" %}
+<!-- Copied from common express with contact link changed -->
+{% extends "base-page.njk" %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set hmpoPageKey = "error.unrecoverable" %}
+
+{% block mainContent %}
+  <h1 data-id="error-title">{{ translate("error.unrecoverable.title") }}</h1>
+
+  <p>{{ translate("error.unrecoverable.subTitle") }}</p>
+
+  <h2>{{ translate("error.unrecoverable.subHeading") }}</h2>
+
+  <div class="govuk-text">
+    <p>{{ translate("error.unrecoverable.description") }}</p>
+  </div>
+
+  {{ govukButton({
+    text: translate("error.unrecoverable.buttonText"),
+    href: translate("error.unrecoverable.buttonLink")
+  }) }}
+
+  <div>
+      <p><a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id\" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ translate("error.unrecoverable.contactMeLink") }}</a></p>
+  </div>
+
+{% endblock %}
+


### PR DESCRIPTION
## Proposed changes

### What changed

Updates support link

### Why did it change

There is a new contact centre URL

### Screenshots

<img width="1792" alt="image" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/40401118/dcfcaa9b-b465-4181-8b4a-8690bac88858">
<img width="1792" alt="Screenshot 2023-10-31 at 10 36 18 am" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/40401118/ba4af3bf-169a-44f1-9a9f-29180d0f17bd">
<img width="1792" alt="Screenshot 2023-10-31 at 10 36 31 am" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/40401118/e63262af-c625-4c67-8308-98ce132c5bd7">
<img width="1792" alt="Screenshot 2023-10-31 at 10 36 39 am" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/40401118/e1f45c0b-4ef9-4e1d-bd3b-313412f25c3d">

### Issue tracking

- [KIWI-1152](https://govukverify.atlassian.net/browse/KIWI-1152)


[KIWI-1152]: https://govukverify.atlassian.net/browse/KIWI-1152?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ