### PR TITLE
KIWI-1486: Implement security rule for ALB

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -264,6 +264,8 @@ Resources:
             Value: !Ref AccessLogsBucket
           - Key: access_logs.s3.prefix
             Value: !Sub cic-front-${Environment}
+          - Key: routing.http.drop_invalid_header_fields.enabled
+            Value: true
         - !Ref AWS::NoValue
 
   LoadBalancerListenerTargetGroupECS:


### PR DESCRIPTION
## Proposed changes

AWS Security compliance to add security rule for load balance

### What changed

Enabled alb-http-drop-invalid-header-enabled set to true

### Why did it change

Security Compliance recommendation

### Issue tracking

- [KIWI-1486](https://govukverify.atlassian.net/browse/KIWI-1486)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->

[KIWI-1486]: https://govukverify.atlassian.net/browse/KIWI-1486?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ