### PR TITLE
INCIDENT-622 Removed debug froms start container command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,4 +37,4 @@ EXPOSE $PORT
 
 ENTRYPOINT ["tini", "--"]
 
-CMD ["yarn", "start:debug"]
+CMD ["yarn", "start"]


### PR DESCRIPTION
## Proposed changes

Removing debug from container start command.

### What changed

Dockerfile start command

### Why did it change

Included debug, overriding env vars.

### Issue tracking

- [INCIDEN-622](https://govukverify.atlassian.net/browse/INCIDEN-622)

[INCIDEN-622]: https://govukverify.atlassian.net/browse/INCIDEN-622?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ