### PR TITLE
[KIWI-1534] - CIC | FE | Flag for GA4 set to False in Prod

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -143,7 +143,7 @@ Mappings:
       SESSIONTABLENAME: "cic-front-sessions-integration"
       GTMIDUA: "GTM-TK92W68"
       GTMIDGA4: "GTM-KD86CMZ"
-      GA4ENABLED: "false"
+      GA4ENABLED: "true"
       ANALYTICSDOMAIN: "integration.account.gov.uk"
       LOGLEVEL: "warn"
     production:
@@ -154,7 +154,7 @@ Mappings:
       SESSIONTABLENAME: "cic-front-sessions-production"
       GTMIDUA: "GTM-TT5HDKV"
       GTMIDGA4: "GTM-K4PBJH3"
-      GA4ENABLED: "false"
+      GA4ENABLED: "true"
       ANALYTICSDOMAIN: "account.gov.uk"
       LOGLEVEL: "warn"
 


### PR DESCRIPTION
### What changed

GA4 flag set to true for integration and prod environments

### Why did it change

To enable Google Analytics 4 for higher environments - this was previously enabled in lower environments for testing purposes, see https://github.com/govuk-one-login/ipv-cri-cic-front/pull/354

### Issue tracking
[KIWI-1534](https://govukverify.atlassian.net/browse/KIWI-1534)

[KIWI-1534]: https://govukverify.atlassian.net/browse/KIWI-1534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ