### PR TITLE
[KIWI-1208] - CIC & F2F | Investigate whether Form Wizard is validating dates correctly

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -76,6 +76,10 @@
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
     },
     {
+      "path": "detect_secrets.filters.common.is_baseline_file",
+      "filename": ".secrets.baseline"
+    },
+    {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
       "min_level": 2
     },
@@ -128,37 +132,37 @@
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 515
+        "line_number": 517
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 517
+        "line_number": 519
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 518
+        "line_number": 520
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 521
+        "line_number": 523
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 523
+        "line_number": 525
       }
     ]
   },
-  "generated_at": "2024-01-05T13:57:58Z"
+  "generated_at": "2024-01-18T09:31:02Z"
 }

--- a/src/app/cic/fields.js
+++ b/src/app/cic/fields.js
@@ -30,7 +30,7 @@ module.exports = {
     journeyKey: "dateOfBirth",
     validate: [
       "required", "date",
-      { type: "before", arguments: [new Date().toISOString().split("T")[0]] },
+      { type: "before", arguments: [] },
       { type: "after", arguments: ["1904-02-12"] }
     ]
   }


### PR DESCRIPTION
### What changed

Removed Date constructor in field validation logic

### Why did it change

Date functions in fields.js are only instantiated when the JS is first created and then pulled in as static value in all future checks - i.e. deployment date. Removed the function in the before / after checks, as those functions then provide their own via Moment.js’ default constructor - see here https://github.com/HMPO/hmpo-form-wizard/blob/a45c5d5207334380fab9e89c34dced46db0aef1f/lib/validation/validators.js#L114

### Issue tracking

- [KIWI-1208](https://govukverify.atlassian.net/browse/KIWI-1208)

### Evidence
Before fix
![Screenshot 2024-01-18 at 08 38 12](https://github.com/govuk-one-login/ipv-cri-cic-front/assets/118540036/8bf27b03-198c-47af-a5e8-a7257326d3d7)
After fix
![Screenshot 2024-01-18 at 09 03 35](https://github.com/govuk-one-login/ipv-cri-cic-front/assets/118540036/e866bf08-a739-483e-ba74-1d7d7efa0bfc)



[KIWI-1208]: https://govukverify.atlassian.net/browse/KIWI-1208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ