### PR TITLE
KIWI-1568: split journey type route into its own

### DIFF
--- a/src/app/cic/controllers/journeyType.js
+++ b/src/app/cic/controllers/journeyType.js
@@ -1,0 +1,21 @@
+const { Controller: BaseController } = require("hmpo-form-wizard");
+const { API } = require("../../../lib/config");
+
+class JourneyTypeController extends BaseController {
+  async saveValues(req, res, next) {
+    try {
+      const headers = {
+        "x-govuk-signin-session-id": req.session.tokenId,
+      }
+
+      const { data } = await req.axios.get(`${API.PATHS.SESSION_CONFIG}`, { headers });
+      req.sessionModel.set("journeyType", data.journey_type);
+      return next();
+    } catch (error) {
+      console.log("Error fetching journey type", error)
+      return next(error);
+    }
+  }
+}
+
+module.exports = JourneyTypeController;

--- a/src/app/cic/controllers/journeyType.test.ts
+++ b/src/app/cic/controllers/journeyType.test.ts
@@ -1,0 +1,57 @@
+const BaseController = require("hmpo-form-wizard").Controller;
+const { expect } = require("chai");
+const { afterEach } = require("mocha");
+const RootController = require('./root.js');
+const { API } = require("../../../lib/config");
+
+console.log = sinon.fake();
+
+describe("RootController", () => {
+  const rootController = new RootController({ route: '/test' });
+  let req;
+  let res;
+  let next;
+  let sandbox;
+
+  beforeEach(() => {
+    sandbox = sinon.createSandbox();
+    const setup = setupDefaultMocks();
+    req = setup.req;
+    res = setup.res;
+    next = setup.next;
+  });
+
+  afterEach(() => {
+    sandbox.restore();
+  });
+
+  it("should be an instance of BaseController", () => {
+    expect(rootController).to.be.an.instanceOf(BaseController);
+  });
+
+  describe("saveValues", () => {
+    it("should fetch the journey type from the session config endpoint", async () => {
+      req.axios.get = sinon.fake.resolves({ data: { journey_type: "FACE_TO_FACE" }});
+
+      await rootController.saveValues(req, res, next);
+
+      sinon.assert.calledWith(
+        req.axios.get,
+        `${API.PATHS.SESSION_CONFIG}`,
+        { headers: { "x-govuk-signin-session-id": req.session.tokenId } }
+      );
+      const journeyType = req.sessionModel.get("journeyType");
+      expect(journeyType).to.equal("FACE_TO_FACE");
+    });
+
+    it("should handle error if call to session config endpoint fails", async () => {
+      req.axios.get = sinon.fake.rejects("Error");
+
+      await rootController.saveValues(req, res, next);
+
+      sinon.assert.calledWith(console.log, "Error fetching journey type");
+      sinon.assert.called(next);
+    });
+  });
+});
+

--- a/src/app/cic/controllers/root.js
+++ b/src/app/cic/controllers/root.js
@@ -1,5 +1,4 @@
 const { Controller: BaseController } = require("hmpo-form-wizard");
-const { API } = require("../../../lib/config");
 
 class RootController extends BaseController {
   async saveValues(req, res, next) {
@@ -14,19 +13,7 @@ class RootController extends BaseController {
         req.sessionModel.set("dateOfBirth", sharedClaims.birthDate[0].value);
       }
     }
-
-    try {
-      const headers = {
-        "x-govuk-signin-session-id": req.session.tokenId,
-      }
-
-      const { data } = await req.axios.get(`${API.PATHS.SESSION_CONFIG}`, { headers });
-      req.sessionModel.set("journeyType", data.journey_type);
-      return next();
-    } catch (error) {
-      console.log("Error fetching journey type", error)
-      return next(error);
-    }
+    super.saveValues(req, res, next);
   }
 }
 

--- a/src/app/cic/controllers/root.test.js
+++ b/src/app/cic/controllers/root.test.js
@@ -2,7 +2,6 @@ const BaseController = require("hmpo-form-wizard").Controller;
 const { expect } = require("chai");
 const { afterEach } = require("mocha");
 const RootController = require('./root.js');
-const { API } = require("../../../lib/config");
 
 console.log = sinon.fake();
 
@@ -94,29 +93,6 @@ describe("RootController", () => {
     expect(firstName).to.equal(undefined);
     expect(surname).to.equal(undefined);
     expect(dateOfBirth).to.equal(undefined);
-  });
-
-  it("should fetch the journey type from the session config endpoint", async () => {
-    req.axios.get = sinon.fake.resolves({ data: { journey_type: "FACE_TO_FACE" }});
-
-    await rootController.saveValues(req, res, next);
-
-    sinon.assert.calledWith(
-      req.axios.get,
-      `${API.PATHS.SESSION_CONFIG}`,
-      { headers: { "x-govuk-signin-session-id": req.session.tokenId } }
-    );
-    const journeyType = req.sessionModel.get("journeyType");
-    expect(journeyType).to.equal("FACE_TO_FACE");
-  });
-
-  it("should handle error if call to session config endpoint fails", async () => {
-    req.axios.get = sinon.fake.rejects("Error");
-
-    await rootController.saveValues(req, res, next);
-
-    sinon.assert.calledWith(console.log, "Error fetching journey type");
-    sinon.assert.called(next);
   });
 });
 

--- a/src/app/cic/steps.js
+++ b/src/app/cic/steps.js
@@ -2,6 +2,7 @@ const nameEntry = require("./controllers/nameEntry");
 const dobEntry = require("./controllers/dateOfBirth");
 const checkDetails = require('./controllers/checkDetails');
 const root = require("./controllers/root");
+const journeyType = require("./controllers/journeyType");
 
 module.exports = {
   "/": {
@@ -10,6 +11,12 @@ module.exports = {
     entryPoint: true,
     skip: true,
     controller: root,
+    next: "journey-type",
+  },
+  "/journey-type": {
+    entryPoint: true,
+    skip: true,
+    controller: journeyType,
     next: "enter-name-photo-id",
   },
   "/enter-name-photo-id": {


### PR DESCRIPTION
## Proposed changes
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

split journey type route into its own

### Why did it change

root controller was causing infinite loop

### Screenshots

<img width="1373" alt="image" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/40401118/4e069f56-b000-451b-926a-543eb91cfaac">

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1568](https://govukverify.atlassian.net/browse/KIWI-1568)


[KIWI-1568]: https://govukverify.atlassian.net/browse/KIWI-1568?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ