### PR TITLE
[KIWI-1528]- CIC | noPID | Additional FE Changes for the No-Photo-ID Route

### DIFF
--- a/src/app/cic/controllers/checkDetails.js
+++ b/src/app/cic/controllers/checkDetails.js
@@ -12,14 +12,15 @@ class CheckDetailsController extends DateController {
       if (err) {
         return callback(err, locals);
       }
-
+      const journeyType = req.sessionModel.get("journeyType");
       const dateOfBirth = req.form.values.dateOfBirth;
       const changeUrl = req.sessionModel.get("changeUrl");
       const firstName = req.sessionModel.get("firstName");
       const middleName = req.sessionModel.get("middleName");
       const surname = req.sessionModel.get("surname")
       const fullName = firstName + " " + middleName + " " + surname
-
+      
+      locals.journeyType = journeyType;
       locals.formattedBirthDate = formatDate(dateOfBirth, "YYYY-MM-DD");
       locals.changeUrl = `/${changeUrl}`;
       locals.fullName = fullName

--- a/src/app/cic/controllers/journeyType.js
+++ b/src/app/cic/controllers/journeyType.js
@@ -5,7 +5,7 @@ class JourneyTypeController extends BaseController {
   async saveValues(req, res, next) {
     try {
       const headers = {
-        "x-govuk-signin-session-id": req.session.tokenId,
+        "x-govuk-signin-session-id": "ec2a7713-7f14-42d8-b8e2-93a85857b6aa",
       }
 
       const { data } = await req.axios.get(`${API.PATHS.SESSION_CONFIG}`, { headers });

--- a/src/app/cic/controllers/journeyType.js
+++ b/src/app/cic/controllers/journeyType.js
@@ -5,7 +5,7 @@ class JourneyTypeController extends BaseController {
   async saveValues(req, res, next) {
     try {
       const headers = {
-        "x-govuk-signin-session-id": "ec2a7713-7f14-42d8-b8e2-93a85857b6aa",
+        "x-govuk-signin-session-id": req.session.tokenId,
       }
 
       const { data } = await req.axios.get(`${API.PATHS.SESSION_CONFIG}`, { headers });

--- a/src/app/cic/controllers/root.js
+++ b/src/app/cic/controllers/root.js
@@ -2,6 +2,9 @@ const { Controller: BaseController } = require("hmpo-form-wizard");
 
 class RootController extends BaseController {
   async saveValues(req, res, next) {
+    
+
+
     const sharedClaims = req.session?.shared_claims;
 
     if (sharedClaims) {

--- a/src/app/cic/steps.js
+++ b/src/app/cic/steps.js
@@ -17,9 +17,9 @@ module.exports = {
     entryPoint: true,
     skip: true,
     controller: journeyType,
-    next: "enter-name-photo-id",
+    next: "enter-name",
   },
-  "/enter-name-photo-id": {
+  "/enter-name": {
     editable: true,
     editBackStep: "confirm-details",
     fields: ["surname", "firstName", "middleName"],

--- a/src/assets/scss/application.scss
+++ b/src/assets/scss/application.scss
@@ -3,13 +3,16 @@ $govuk-assets-path: "/public/";
 @import "../../../node_modules/govuk-frontend/govuk/all";
 @import "../../../node_modules/hmpo-components/all";
 
-// Adding a new rule in case adjusting the component CSS directly is bad practice
 .govuk-radios__item {
   @include govuk-responsive-margin(6, $direction: "bottom", $important: false, $adjustment: false);
 }
 
 .govuk-heading-m, .hmpo-auto-submit h1, h2 {
   @include govuk-responsive-margin(6, "bottom")
+}
+
+.govuk-heading-l {
+  @include govuk-responsive-margin(3, "bottom")
 }
 
 .govuk-fieldset__heading {
@@ -54,7 +57,12 @@ $govuk-assets-path: "/public/";
 }
 
 .govuk-warning-text {
-  @include govuk-responsive-margin(0, "bottom")
+  @include govuk-responsive-margin(0, "bottom");
+  @include govuk-responsive-margin(3, "top");
+}
+
+#confirmDetailsContinue {
+  @include govuk-responsive-margin(6, "top");
 }
 
 #details-btn {

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -2,7 +2,7 @@ require("dotenv").config();
 
 module.exports = {
   API: {
-    BASE_URL: process.env.API_BASE_URL || "http://localhost:8090",
+    BASE_URL: process.env.API_BASE_URL || "https://api-cic-cri-api.review-c.dev.account.gov.uk",
     PATHS: {
       SESSION: "/session",
       AUTHORIZATION: "/authorization",
@@ -14,7 +14,7 @@ module.exports = {
     BASE_URL: process.env.EXTERNAL_WEBSITE_HOST || "http://localhost:8000",
     PATHS: {
       CIC: "/",
-      NAME_ENTRY: "/enter-name-photo-id",
+      NAME_ENTRY: "/enter-name",
       DATE_OF_BIRTH: "/enter-date-birth",
       CHECK_DETAILS: "/confirm-details",
     },

--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -32,7 +32,7 @@ govuk:
     cookieLinkText: "Darganfyddwch fwy am gwcis"
   phaseBanner:
     tag: beta
-    content: Mae hwn yn wasanaeth newydd – bydd eich <a href=\"https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id\" target=\"_blank\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella.
+    content: Mae hwn yn wasanaeth newydd – bydd eich <a href=\"https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name\" target=\"_blank\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella.
   footerNavItems:
     meta:
       items:
@@ -44,7 +44,7 @@ govuk:
           text: Telerau ac amodau
         - href: https://signin.account.gov.uk/privacy-notice
           text: Hysbysiad preifatrwydd
-        - href: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id
+        - href: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name
           text: Cymorth
   copyright:
     text: "© Hawlfraint y Goron"

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -61,4 +61,3 @@ checkDetails:
   legend: ""
   validation:
     default: "Gwnewch yn siwr bod y manylion rydych wedi eu rhoi yn cyd-fynd â'r manylion ar eich ID gyda llun."
-    noPhotoId: "Ni allwch newid eich enw a'ch dyddiad geni ar ôl i chi barhau i'r dudalen nesaf."

--- a/src/locales/cy/fields.yml
+++ b/src/locales/cy/fields.yml
@@ -61,3 +61,4 @@ checkDetails:
   legend: ""
   validation:
     default: "Gwnewch yn siwr bod y manylion rydych wedi eu rhoi yn cyd-fynd â'r manylion ar eich ID gyda llun."
+    noPhotoId: "Ni allwch newid eich enw a'ch dyddiad geni ar ôl i chi barhau i'r dudalen nesaf."

--- a/src/locales/cy/pages.errors.yml
+++ b/src/locales/cy/pages.errors.yml
@@ -16,7 +16,7 @@ pageNotFound:
     - Os ydych wedi gludo'r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo'r cyfeiriad cyfan.",
     - Gallwch hefyd fynd yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.",
     - <a href=\"https://www.gov.uk/\" class=\"govuk-button\" data-module=\"govuk-button\">Ewch i hafan GOV.UK</a>",
-    - <a href=\"https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id\" target=\"_blank\" class=\"govuk-link\">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>"
+    - <a href=\"https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name\" target=\"_blank\" class=\"govuk-link\">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>"
 
 
 sessionEnded:

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -7,9 +7,6 @@ nameEntry:
   firstName: "Enw cyntaf"
   middleName: "Enwau canol"
   middleNameHint: "Gadewch hwn yn wag os nad oes gennych enwau canol"
-  contactSupport: 
-    text: "Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)"
-    link: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name" target="_blank" class="govuk-link" rel="noopener" target="_blank
   FACE_TO_FACE:
     title: "Rhowch eich enw yn union fel y mae'n ymddangos ar eich ID gyda llun"
 

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -7,6 +7,9 @@ nameEntry:
   firstName: "Enw cyntaf"
   middleName: "Enwau canol"
   middleNameHint: "Gadewch hwn yn wag os nad oes gennych enwau canol"
+  contactSupport: 
+    text: "Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)"
+    link: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name" target="_blank" class="govuk-link" rel="noopener" target="_blank
   FACE_TO_FACE:
     title: "Rhowch eich enw yn union fel y mae'n ymddangos ar eich ID gyda llun"
 
@@ -15,7 +18,8 @@ checkDetails:
   name: "Enw"
   dateOfBirth: "Dyddiad geni"
   changeLink: "Newid"
-  buttonText: "Rwy'n cadarnhau bod fy manylion yn gywir"
+  f2fButtonText: "Rwy'n cadarnhau bod fy manylion yn gywir"
+  noPidButtonText: "Cadarnhau a pharhau"
 
 dateOfBirth:
   title: "Rhowch eich dyddiad geni"

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -16,7 +16,7 @@ checkDetails:
   dateOfBirth: "Dyddiad geni"
   changeLink: "Newid"
   f2fButtonText: "Rwy'n cadarnhau bod fy manylion yn gywir"
-  noPidButtonText: "Cadarnhau a pharhau"
+  noPidButtonText: "Rwy'n cadarnhau bod fy manylion yn gywir"
 
 dateOfBirth:
   title: "Rhowch eich dyddiad geni"

--- a/src/locales/en/default.yml
+++ b/src/locales/en/default.yml
@@ -32,7 +32,7 @@ govuk:
     cookieLinkText: "Find out more about cookies"
   phaseBanner:
     tag: beta
-    content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id" target="_blank" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
+    content: This is a new service – your <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name" target="_blank" class="govuk-link" rel="noopener" target="_blank">feedback (opens in new tab)</a> will help us to improve it.
   footerNavItems:
     meta:
       items:
@@ -44,7 +44,7 @@ govuk:
           text: Terms and conditions
         - href: https://signin.account.gov.uk/privacy-notice
           text: Privacy notice
-        - href: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id
+        - href: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name
           text: Support
   copyright:
     text: "© Crown copyright"

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -59,4 +59,4 @@ checkDetails:
   legend: ""
   validation:
     default: "Make sure the details you entered match the details on your photo ID."
-    noPhotoId: "You cannot change your name and date of birth once you continue to the next page"
+    noPhotoId: "You cannot change your name and date of birth once you continue to the next page."

--- a/src/locales/en/fields.yml
+++ b/src/locales/en/fields.yml
@@ -59,3 +59,4 @@ checkDetails:
   legend: ""
   validation:
     default: "Make sure the details you entered match the details on your photo ID."
+    noPhotoId: "You cannot change your name and date of birth once you continue to the next page"

--- a/src/locales/en/pages.errors.yml
+++ b/src/locales/en/pages.errors.yml
@@ -16,7 +16,7 @@ pageNotFound:
     - If you pasted the web address, check you copied the entire address.
     - You can also go back to the service you were trying to use and start again. You can look for the service using your search engine or find it from the GOV.UK homepage.
     - <a href="https://www.gov.uk/" class="govuk-button" data-module="govuk-button">Go to the GOV.UK homepage</a>
-    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id" target="_blank" class="govuk-link">Contact the GOV.UK One Login team (opens in a new tab)</a>
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name" target="_blank" class="govuk-link">Contact the GOV.UK One Login team (opens in a new tab)</a>
 
 
 sessionEnded:

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -7,6 +7,9 @@ nameEntry:
   firstName: "First name"
   middleName: "Middle names"
   middleNameHint: "Leave this blank if you do not have middle names"
+  contactSupport: 
+    text: "Contact the GOV.UK One Login team (opens in a new tab)"
+    link: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name" target="_blank" class="govuk-link" rel="noopener" target="_blank
   FACE_TO_FACE:
     title: "Enter your name exactly as it appears on your photo ID"
   NO_PHOTO_ID:
@@ -20,7 +23,8 @@ checkDetails:
   name: "Name"
   dateOfBirth: "Date of birth"
   changeLink: "Change"
-  buttonText: "I confirm my details are correct"
+  f2fButtonText: "I confirm my details are correct"
+  noPidButtonText: "Confirm and continue"
 
 dateOfBirth:
   title: "Enter your date of birth"

--- a/src/views/cic/confirm-details.html
+++ b/src/views/cic/confirm-details.html
@@ -12,54 +12,70 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds-from-desktop">
     <h1 class="govuk-heading-l">{{ translate("checkDetails.title") }}</h1>
-    {{ govukWarningText({
-      text: translate("checkDetails.validation.default"),
-      iconFallbackText: "Warning"
+
+    {% if (journeyType == "FACE_TO_FACE") %}
+      {{ govukWarningText({
+        text: translate("checkDetails.validation.default"),
+        iconFallbackText: "Warning"
+      }) }}
+    {% endif %}
+
+    {{ govukSummaryList({
+      classes: 'govuk-!-margin-bottom-0',
+      rows: [
+        {
+          key: {
+            text: translate("checkDetails.name")
+          },
+          value: {
+            html: translate("{{ fullName }}")
+          },
+          actions: {
+            items: [
+              {
+                href: "/enter-name/edit",
+                text: translate("checkDetails.changeLink"),
+                visuallyHiddenText: translate("checkDetails.name")
+              }
+            ]
+          }
+        },
+        {
+          key: {
+            text: translate("checkDetails.dateOfBirth")
+          },
+          value: {
+            html: translate("{{ formattedBirthDate }}")
+          },
+          actions: {
+            items: [
+              {
+                href: "/enter-date-birth/edit",
+                text: translate("checkDetails.changeLink"),
+                visuallyHiddenText: translate("checkDetails.dateOfBirth")
+              }
+            ]
+          }
+        }
+      ]
     }) }}
 
-      {{ govukSummaryList({
-        classes: 'govuk-!-margin-bottom-0',
-        rows: [
-          {
-            key: {
-              text: translate("checkDetails.name")
-            },
-            value: {
-              html: translate("{{ fullName }}")
-            },
-            actions: {
-              items: [
-                {
-                  href: "/enter-name-photo-id/edit",
-                  text: translate("checkDetails.changeLink"),
-                  visuallyHiddenText: translate("checkDetails.name")
-                }
-              ]
-            }
-          },
-          {
-            key: {
-              text: translate("checkDetails.dateOfBirth")
-            },
-            value: {
-              html: translate("{{ formattedBirthDate }}")
-            },
-            actions: {
-              items: [
-                {
-                  href: "/enter-date-birth/edit",
-									text: translate("checkDetails.changeLink"),
-                  visuallyHiddenText: translate("checkDetails.dateOfBirth")
-                }
-              ]
-            }
-          }
-        ]
+    {% if (journeyType == "NO_PHOTO_ID") %}
+      {{ govukWarningText({
+        text: translate("checkDetails.validation.noPhotoId"),
+        iconFallbackText: "Warning"
       }) }}
+    {% endif %}
 
-       {% call hmpoForm(ctx) %}
-      {{ hmpoSubmit(ctx, {id: "continue", text: translate("checkDetails.buttonText")}) }}
-         {% endcall %}
+    {% if (journeyType == "NO_PHOTO_ID") %}
+      {% call hmpoForm(ctx) %}
+        {{ hmpoSubmit(ctx, {id: "confirmDetailsContinue", text: translate("checkDetails.noPidButtonText")}) }}
+      {% endcall %}
+    {% else %}
+      {% call hmpoForm(ctx) %}
+        {{ hmpoSubmit(ctx, {id: "confirmDetailsContinue", text: translate("checkDetails.f2fButtonText")}) }}
+      {% endcall %}
+    {% endif %}
     </div>
   </div>
 

--- a/src/views/cic/enter-name.html
+++ b/src/views/cic/enter-name.html
@@ -52,6 +52,8 @@
 
   {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
 
+  <p> <a href={{ "nameEntry.contactSupport.link" | translate }}> {{ "nameEntry.contactSupport.text" | translate }}</a></p>
+
   {% endcall %}
 
 {% endblock %}

--- a/src/views/cic/enter-name.html
+++ b/src/views/cic/enter-name.html
@@ -20,11 +20,13 @@
   </div>
 
   {% if journeyType === "NO_PHOTO_ID" %}
+  <div id="noPhotoIdInstructions">
     <p>{{ introText }}</p>
     <div class="govuk-inset-text govuk-!-margin-bottom-6">
       <p>{{ insetText1 }}</p>
       <p>{{ insetText2 }}</p>
     </div>
+  </div>
   {% endif %}
 
   {% call hmpoForm(ctx, {attributes: {onsubmit: 'window.disableFormSubmit()'} }) %}
@@ -52,7 +54,7 @@
 
   {{ hmpoSubmit(ctx, {id: "continue", text: translate("buttons.next")}) }}
 
-  <p> <a href={{ "nameEntry.contactSupport.link" | translate }}> {{ "nameEntry.contactSupport.text" | translate }}</a></p>
+  <p> <a href={{ "nameEntry.contactSupport.link" | translate }} id="contactSupport"> {{ "nameEntry.contactSupport.text" | translate }}</a></p>
 
   {% endcall %}
 

--- a/src/views/errors/error.html
+++ b/src/views/errors/error.html
@@ -21,7 +21,7 @@
   }) }}
 
   <div>
-      <p><a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-photo-id\" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ translate("error.unrecoverable.contactMeLink") }}</a></p>
+      <p><a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name\" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ translate("error.unrecoverable.contactMeLink") }}</a></p>
   </div>
 
 {% endblock %}

--- a/test/browser/features/BrowserBasedTests/HappyPath/Journey/CICDoBEntryScreen.feature
+++ b/test/browser/features/BrowserBasedTests/HappyPath/Journey/CICDoBEntryScreen.feature
@@ -4,7 +4,7 @@ Feature: The user enters their Date of Birth as part of their claimed identity
 Background:
     Given Authenticatable Anita is using the system
     When they have provided their details
-    Then they should be redirected to the nameEntry
+    Then they should be redirected to the F2F nameEntry
 
     Given there has been an entry into the surname and first name fields
     When the user clicks the NameEntry continue button

--- a/test/browser/features/BrowserBasedTests/HappyPath/Journey/CICEndToEnd.feature
+++ b/test/browser/features/BrowserBasedTests/HappyPath/Journey/CICEndToEnd.feature
@@ -5,7 +5,7 @@ Feature: Claimed Identity Credential Issuer - E2E
 Scenario: Claimed Identity Credential Issuer - E2E Happy Path and DB Validation
     Given Authenticatable Anita is using the system
     When they have provided their details
-    Then they should be redirected to the nameEntry
+    Then they should be redirected to the F2F nameEntry
 
     Given there has been an entry into the surname and first name fields
     When the user clicks the NameEntry continue button

--- a/test/browser/features/BrowserBasedTests/HappyPath/Journey/CICNameEntryScreen.feature
+++ b/test/browser/features/BrowserBasedTests/HappyPath/Journey/CICNameEntryScreen.feature
@@ -1,12 +1,19 @@
 @mock-api:f2f-cic-success @success @browser
 Feature: The user enters their name to be used as part of their claimed identity
 
-Background:
-    Given Authenticatable Anita is using the system
+Scenario: Successful validation of Surname and First name fields
+    Given Validating Valerie is using the system
     When they have provided their details
-    Then they should be redirected to the nameEntry
+    Then they should be redirected to the BAV nameEntry
+
 
 Scenario: Successful validation of Surname and First name fields
-Given there has been an entry into the surname and first name fields
-When the user clicks the NameEntry continue button
-Then the user is routed to the next screen in the journey DOB Entry
+    Given Authenticatable Anita is using the system
+    When they have provided their details
+    Then they should be redirected to the F2F nameEntry
+    Given there has been an entry into the surname and first name fields
+    When the user clicks the NameEntry continue button
+    Then the user is routed to the next screen in the journey DOB Entry
+
+
+

--- a/test/browser/features/BrowserBasedTests/HappyPath/Journey/CICSupportLinkScreen.feature
+++ b/test/browser/features/BrowserBasedTests/HappyPath/Journey/CICSupportLinkScreen.feature
@@ -1,0 +1,15 @@
+@mock-api:f2f-cic-success @success @browser
+Feature: The user want to access GOV UK support link 
+
+Scenario: Successful redirect to support link from BAV page
+    Given Validating Valerie is using the system
+    When the user clicks the GOV UK support Link
+    Then they should be redirected to the GOV UK support page 
+
+Scenario: Successful redirect to support link from F2F page
+    Given Authenticatable Anita is using the system
+    When the user clicks the GOV UK support Link
+    Then they should be redirected to the GOV UK support page 
+
+
+

--- a/test/browser/features/BrowserBasedTests/UnHappyPath/BackButton/CICCheckAnswersScreenGoBack.feature
+++ b/test/browser/features/BrowserBasedTests/UnHappyPath/BackButton/CICCheckAnswersScreenGoBack.feature
@@ -5,7 +5,7 @@ Feature: Successful navigation using the Back button on the CMA screen
 Background:
     Given Authenticatable Anita is using the system
     When they have provided their details
-    Then they should be redirected to the nameEntry
+    Then they should be redirected to the F2F nameEntry
 
     Given there has been an entry into the surname and first name fields
     When the user clicks the NameEntry continue button

--- a/test/browser/features/BrowserBasedTests/UnHappyPath/ChangeButton/CICCheckAnswersDoBCheckAnswers.feature
+++ b/test/browser/features/BrowserBasedTests/UnHappyPath/ChangeButton/CICCheckAnswersDoBCheckAnswers.feature
@@ -4,7 +4,7 @@ Feature: Successful navigation using Change and Back button - Date of Birth
   Background:
       Given Authenticatable Anita is using the system
       When they have provided their details
-      Then they should be redirected to the nameEntry
+      Then they should be redirected to the F2F nameEntry
 
       Given there has been an entry into the surname and first name fields
       When the user clicks the NameEntry continue button

--- a/test/browser/features/BrowserBasedTests/UnHappyPath/ChangeButton/CICCheckAnswersNameEntryCheckAnswers.feature
+++ b/test/browser/features/BrowserBasedTests/UnHappyPath/ChangeButton/CICCheckAnswersNameEntryCheckAnswers.feature
@@ -5,7 +5,7 @@ Feature: Successful navigation using Change and Back button - Name Entry
     Background:
         Given Authenticatable Anita is using the system
         When they have provided their details
-        Then they should be redirected to the nameEntry
+        Then they should be redirected to the F2F nameEntry
 
         Given there has been an entry into the surname and first name fields
         When the user clicks the NameEntry continue button

--- a/test/browser/features/BrowserBasedTests/UnHappyPath/InlineValidation/CICDoBEntryScreenInlineError.feature
+++ b/test/browser/features/BrowserBasedTests/UnHappyPath/InlineValidation/CICDoBEntryScreenInlineError.feature
@@ -5,7 +5,7 @@ Feature: Error Message displayed when wrong DoB is entered
     Background:
         Given Authenticatable Anita is using the system
         When they have provided their details
-        Then they should be redirected to the nameEntry
+        Then they should be redirected to the F2F nameEntry
 
         Given there has been an entry into the surname and first name fields
         When the user clicks the NameEntry continue button

--- a/test/browser/features/BrowserBasedTests/UnHappyPath/InlineValidation/CICNameEntryScreenMissValue.feature
+++ b/test/browser/features/BrowserBasedTests/UnHappyPath/InlineValidation/CICNameEntryScreenMissValue.feature
@@ -5,7 +5,7 @@ Feature:Error messgae is displayed when no name data is entered
     Background:
         Given Authenticatable Anita is using the system
         When they have provided their details
-        Then they should be redirected to the nameEntry
+        Then they should be redirected to the F2F nameEntry
 
 
     Scenario: Successful validation of Surname and First name fields

--- a/test/browser/pages/checkDetailsPage.js
+++ b/test/browser/pages/checkDetailsPage.js
@@ -58,4 +58,9 @@ module.exports = class PlaywrightDevPage {
   async changeDoB(){
     await this.doBLink.click();
   }
+  async checkWarning() {
+    const warningText = await this.page.locator(".govuk-warning-text__assistive").textContent();
+      return warningText.trim();
+    }
 };
+

--- a/test/browser/pages/checkDetailsPage.js
+++ b/test/browser/pages/checkDetailsPage.js
@@ -44,7 +44,7 @@ module.exports = class PlaywrightDevPage {
   }
 
   get nameEntryLink() {
-    return this.page.locator('[href*="/enter-name-photo-id/edit"]')
+    return this.page.locator('[href*="/enter-name/edit"]')
   }
 
   async changeName(){

--- a/test/browser/pages/nameEntryPage.js
+++ b/test/browser/pages/nameEntryPage.js
@@ -16,6 +16,10 @@ module.exports = class PlaywrightDevPage {
   async continue() {
     await this.page.click("#continue");
   }
+  
+  async clickSupportLink() {
+    await this.page.locator("#contactSupport").click();
+  }
 
   async enterSurname() {
     await this.page.locator("#surname").fill("Hartley");
@@ -42,7 +46,15 @@ module.exports = class PlaywrightDevPage {
     return errorText.trim();
   }
 
-};
+  async checkTitle() {
+    const titleText = await this.page.locator("#header").textContent();
+    return titleText.trim();
+  }
 
+  async checkSubTitleForBAV() {
+    const subTitleText = await this.page.locator("#noPhotoIdInstructions").textContent();
+    return subTitleText.trim();
+  }
+};
 
 

--- a/test/browser/pages/nameEntryPage.js
+++ b/test/browser/pages/nameEntryPage.js
@@ -4,7 +4,7 @@ module.exports = class PlaywrightDevPage {
    */
   constructor(page) {
     this.page = page;
-    this.path = "/enter-name-photo-id";
+    this.path = "/enter-name";
     this.firstName;
   }
 

--- a/test/browser/pages/nameEntryPageEdit.js
+++ b/test/browser/pages/nameEntryPageEdit.js
@@ -6,7 +6,7 @@ module.exports = class PlaywrightDevPage {
      */
     constructor(page) {
       this.page = page;
-      this.path = "/enter-name-photo-id/edit";
+      this.path = "/enter-name/edit";
     }
   
     async isCurrentPage() {  

--- a/test/browser/pages/relying-party.js
+++ b/test/browser/pages/relying-party.js
@@ -9,10 +9,10 @@ module.exports = class PlaywrightDevPage {
     this.page = page;
   }
 
-  async goto() {
+  async goto(claim) {
 
     const axios = require("axios");
-    const claim = require("../support/shared_claim")
+    
 
     const postRequest = await axios.post(process.env.IPV_STUB_URL, claim);
 

--- a/test/browser/step_definitions/CICCheckAnswers.step.js
+++ b/test/browser/step_definitions/CICCheckAnswers.step.js
@@ -8,11 +8,10 @@ const ApiSupport = require("../support/ApiSupport");
 
 const TestHarness = require("../support/TestHarness");
 
+
 Given(/^the user has completed the previous CIC screens$/, async function () {
   const cpdPage = new CheckDetailsPage(await this.page);
-
   expect(await cpdPage.isCurrentPage()).to.be.true;
-
 });
 
 When(/^the user clicks the Check My Answers Submit button$/, { timeout: 2 * 50000 }, async function () {
@@ -21,8 +20,7 @@ When(/^the user clicks the Check My Answers Submit button$/, { timeout: 2 * 5000
   await cmPage.continue();
   this.state = await cmPage.setSessionState();
   this.authCode = await cmPage.setAuthCode();
-})
-
+});
 
 Given(/^I have retrieved the sessionTable data for my CIC session$/, { timeout: 2 * 50000 }, async function () {
   const testHarness = new TestHarness();
@@ -34,13 +32,13 @@ Given(/^I have retrieved the sessionTable data for my CIC session$/, { timeout: 
   this.authSessionState = session.authSessionState;
   this.authorizationCode = session.authorizationCode;
   this.redirectUri = session.redirectUri;
-})
+});
 
 
 Then(/^session details are correctly stored in DB$/, { timeout: 2 * 50000 }, async function () {
   expect(this.sessionId).to.not.be.null;
   expect(this.authSessionState).to.equal("CIC_AUTH_CODE_ISSUED");
-})
+});
 
 Then(/^the Verifiable Credential is correctly returned by the userInfo endpoint$/, { timeout: 2 * 50000 }, async function () {
   const apiSupport = new ApiSupport(process.env.CRI_F2F_API_URL);
@@ -48,5 +46,5 @@ Then(/^the Verifiable Credential is correctly returned by the userInfo endpoint$
   const userInfoRequest = await apiSupport.userInfoPostRequest(tokenRequest.data.access_token);
   const jwtToken  = await apiSupport.getJwtTokenUserInfo(JSON.stringify(userInfoRequest.data));
   await apiSupport.validateJwtToken(jwtToken);
-})
+});
 

--- a/test/browser/step_definitions/CICNameEntry.step.js
+++ b/test/browser/step_definitions/CICNameEntry.step.js
@@ -1,29 +1,50 @@
-const { Given, When, Then} = require("@cucumber/cucumber");
+const { Given, When, Then } = require("@cucumber/cucumber");
 
 const { expect } = require("chai");
 
-const { NameEntryPage, DateOfBirthPage, EuDrivingLicenceDetailsPageValid }  = require("../pages");
+const {
+  NameEntryPage,
+  DateOfBirthPage,
+  EuDrivingLicenceDetailsPageValid,
+} = require("../pages");
 
-const userData = require("../support/cicUserData.json")
+const userData = require("../support/cicUserData.json");
 
-Given(
-  /^there has been an entry into the surname and first name fields$/,
-  async function () {
+Given(/^there has been an entry into the surname and first name fields$/,async function () {
     const nameEntryPage = new NameEntryPage(await this.page);
 
     await nameEntryPage.enterSurname(userData.lastName);
     await nameEntryPage.enterFirstName(userData.firstName);
     await nameEntryPage.enterMiddleName(userData.middleName);
-
   }
 );
 
-When(/^the user clicks the NameEntry continue button$/, async function () {
+When(/^the user clicks the GOV UK support Link$/, async function () {
   const nameEntryPage = new NameEntryPage(await this.page);
 
-  await nameEntryPage.continue();
+  //setup promise to catch a 'open new tab' event
+  const newTabPromise = this.page.waitForEvent("popup");
+  await nameEntryPage.clickSupportLink();
 
+  // after clicking the link a new tab should have opened
+  // assign the caught event to the new tab variable to called elsewhere
+  this.supportTab = await newTabPromise;
+  await this.supportTab.waitForLoadState();
 });
+
+When(/^the user clicks the NameEntry continue button$/, async function () {
+  const nameEntryPage = new NameEntryPage(await this.page);
+  await nameEntryPage.continue();
+});
+
+Then(
+  /^they should be redirected to the GOV UK support page$/,
+  async function () {
+    expect(await this.supportTab.url()).to.contain(
+      "https://home.account.gov.uk/contact-gov-uk-one-login",
+    );
+  },
+);
 
 Then(
   /^the user is routed to the next screen in the journey DOB Entry$/,
@@ -31,8 +52,7 @@ Then(
     const dobPage = new DateOfBirthPage(await this.page);
 
     expect(await dobPage.isCurrentPage()).to.be.true;
-
-  }
+  },
 );
 
 Given(/^only one mandatory name field has been entered$/, async function () {
@@ -40,53 +60,51 @@ Given(/^only one mandatory name field has been entered$/, async function () {
 
   await nameEntryPage.enterSurname();
   await nameEntryPage.enterMiddleName();
-
-}
-);
-
-When(
-/^the user clicks the continue button in the NameEntry screen$/, async function () {
-const nameEntryPage = new NameEntryPage(await this.page);
-
-await nameEntryPage.continue();
-
 });
 
+When(
+  /^the user clicks the continue button in the NameEntry screen$/,
+  async function () {
+    const nameEntryPage = new NameEntryPage(await this.page);
+    await nameEntryPage.continue();
+  },
+);
+
 Then(
-/^the user sees an inline error message displayed in the NameEntry screen$/,
-async function () {
-  const nameEntryPage = new NameEntryPage(await this.page);
+  /^the user sees an inline error message displayed in the NameEntry screen$/,
+  async function () {
+    const nameEntryPage = new NameEntryPage(await this.page);
 
-  expect(await nameEntryPage.isCurrentPage()).to.be.true;
+    expect(await nameEntryPage.isCurrentPage()).to.be.true;
 
-  const inlineError = 'There is a problem';
+    const inlineError = "There is a problem";
 
-  const error = await nameEntryPage.checkErrorText();
-    
-  expect(await error).to.equal(inlineError);
-  
-}
+    const error = await nameEntryPage.checkErrorText();
+
+    expect(await error).to.equal(inlineError);
+  },
 );
 
 Given(/^the user has navigated to the Name Entry screen$/, async function () {
   const nameEntryPage = new NameEntryPage(await this.page);
 
   expect(await nameEntryPage.isCurrentPage()).to.be.true;
-
 }
 );
 
 When(/^the Back link is clicked on the Name Entry screen$/, async function () {
-const nameEntryPage = new NameEntryPage(await this.page);
+  const nameEntryPage = new NameEntryPage(await this.page);
 
-await nameEntryPage.back();
-
+  await nameEntryPage.back();
 });
 
-Then(/^the user is navigated back to the screen that they came from$/,async function () {
-const euDLDetailsPage = new EuDrivingLicenceDetailsPageValid(await this.page);
+Then(
+  /^the user is navigated back to the screen that they came from$/,
+  async function () {
+    const euDLDetailsPage = new EuDrivingLicenceDetailsPageValid(
+      await this.page,
+    );
 
-expect(await euDLDetailsPage.isCurrentPage()).to.be.true;
-  
-}
+    expect(await euDLDetailsPage.isCurrentPage()).to.be.true;
+  },
 );

--- a/test/browser/step_definitions/details.js
+++ b/test/browser/step_definitions/details.js
@@ -4,11 +4,11 @@ const { RelyingPartyPage, LandingPage, NameEntryPage } = require("../pages");
 
 const { expect } = require("chai");
 
-Given(/^([A-Za-z ])+is using the system$/, {timeout: 2 * 5000}, async function (name) {
-  this.user = this.allUsers[name];
+Given(/^([^"]*) is using the system$/, {timeout: 2 * 5000}, async function (name) {
+  const claim = this.allUserClaims[name];
   const rpPage = new RelyingPartyPage(this.page);
 
-  await rpPage.goto();
+  await rpPage.goto(claim);
 });
 
 When("they have provided their details",{
@@ -22,12 +22,19 @@ Then("they should be redirected to the landingPage", async function () {
   expect(await landingPage.isCurrentPage()).to.be.true;
 });
 
-Then("they should be redirected to the nameEntry", async function () {
-  const nameEntry = new NameEntryPage(await this.page);
+Then("they should be redirected to the F2F nameEntry", async function () {
+  const nameEntryPage = new NameEntryPage(await this.page);
+  expect(await nameEntryPage.isCurrentPage()).to.be.true;
+  expect(await nameEntryPage.checkTitle()).to.contain("Enter your name exactly as it appears on your photo ID");
 
-  expect(await nameEntry.isCurrentPage()).to.be.true;
 });
 
+Then("they should be redirected to the BAV nameEntry", async function () {
+  const nameEntryPage = new NameEntryPage(await this.page);
+  expect(await nameEntryPage.isCurrentPage()).to.be.true;
+  expect(await nameEntryPage.checkTitle()).to.contain("Enter your name as it appears on your bank or building society account");
+  expect(await nameEntryPage.checkSubTitleForBAV()).to.contain("Check your banking app, online bank account or bank statement for the full registered name."&&"The name on your bank card might only use your initials.");
+});
 
 Then("they should be redirected as an error", function () {
   const rpPage = new RelyingPartyPage(this.page);
@@ -36,3 +43,5 @@ Then("they should be redirected as an error", function () {
 
   expect(rpPage.hasErrorQueryParams()).to.be.true;
 });
+
+      

--- a/test/browser/support/env.js
+++ b/test/browser/support/env.js
@@ -2,16 +2,16 @@ const { setWorldConstructor } = require("@cucumber/cucumber");
 
 require("playwright");
 
-const users = {
-  "Authenticatable Anita": {},
+const userClaims = {
+  "Authenticatable Anita": require("../support/shared_claim_f2f"),
   "Erroring Ethem": {},
   "Not Authenticatable Neil": {},
-  "Validating Valerie": {},
+  "Validating Valerie": require("../support/shared_claim_bav"),
 };
 
 class CustomWorld {
   constructor() {
-    this.allUsers = users;
+    this.allUserClaims = userClaims;
   }
 }
 

--- a/test/browser/support/shared_claim_bav.json
+++ b/test/browser/support/shared_claim_bav.json
@@ -24,5 +24,7 @@
             }
         ],
         "email": "zac.mohamoud@digital.cabinet-office.gov.uk"
-    }
+    },
+
+    "context": "bank_account"
 }

--- a/test/browser/support/shared_claim_f2f.json
+++ b/test/browser/support/shared_claim_f2f.json
@@ -1,0 +1,28 @@
+{
+    "shared_claims": {
+        "name": [
+            {
+                "nameParts": [
+                    {
+                        "value": "API",
+                        "type": "GivenName"
+                    },
+                    {
+                        "value": "Automation",
+                        "type": "GivenName"
+                    },
+                    {
+                        "value": "Test",
+                        "type": "FamilyName"
+                    }
+                ]
+            }
+        ],
+        "birthDate": [
+            {
+                "value": "1960-02-02"
+            }
+        ],
+        "email": "zac.mohamoud@digital.cabinet-office.gov.uk"
+    }
+}


### PR DESCRIPTION
### What changed

Copy changes to Check Details page dependent on journey_type flag, URL change and contact help link added

### Why did it change

To make it clear to no photo ID users that they can't change their details after this step. Needed for BAV

### Issue tracking

- [KIWI-1528](https://govukverify.atlassian.net/browse/KIWI-1528)

## Checklists

![Screenshot 2024-01-31 at 11 11 20](https://github.com/govuk-one-login/ipv-cri-cic-front/assets/117987734/d1405b85-9c50-422b-a879-5674c53cdb12)
![Screenshot 2024-01-31 at 11 11 11](https://github.com/govuk-one-login/ipv-cri-cic-front/assets/117987734/2794cfe0-4a54-42c1-86bb-ff3de99a1bc6)



### Other considerations
<!-- Add any other consideration if needed -->

[KIWI-1528]: https://govukverify.atlassian.net/browse/KIWI-1528?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ