### PR TITLE
[KIWI-1676] Adding PII checklogs script for automation

### DIFF
--- a/check-logs.sh
+++ b/check-logs.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+test_data="./test/browser/support/cicUserData.json"
+firstName=$(jq -r '.firstName' "$test_data")
+middleName=$(jq -r '.middleName' "$test_data")
+lastName=$(jq -r '.lastName' "$test_data")
+birthDate=$(jq -r '.dob' "$test_data")
+
+query="fields @timestamp, @message, @logStream, @log | filter @message like \"$firstName\""
+
+function update_query_string() {
+  # Get the array of search strings as arguments  
+  local searchStrings=("$@")
+
+  for value in "${searchStrings[@]}"
+  do
+    query+=" or @message like \"$value\""
+  done
+
+  # Return the updated query string
+  echo $query
+}
+
+query=$(update_query_string $middleName $lastName $birthDate)
+echo $query
+
+stack_name="cic-cri-front"
+log_groups=(
+    "/aws/ecs/$stack_name-CICFront-ECS"
+)
+
+current_epoch=$(date +%s)
+fifteen_mins_ago_epoch=$((current_epoch - (15 * 60)))
+
+start_time=$fifteen_mins_ago_epoch
+end_time=$current_epoch
+
+query_id=$(aws logs start-query \
+    --log-group-names "${log_groups[@]}" \
+    --start-time "$start_time" \
+    --end-time "$end_time" \
+    --query-string "$query" \
+    --output text --query 'queryId')
+
+status="Running"
+while [ "$status" = "Running" ]; do
+    echo "Waiting for query to complete..."
+    sleep 1
+    query_status=$(aws logs get-query-results --query-id "$query_id")
+    status=$(echo "$query_status" | grep -o '"status": "[^"]*"' | cut -d '"' -f 4)
+done
+
+if echo "$query_status" | grep -q '"results": \[\]'; then
+    echo "Query found no PII 🎉"
+    exit 0
+else
+    echo "Query returned results:"
+    echo "$query_status" | jq -r '.results[] | @json'
+    exit 1
+fi

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "test:browser:report": "node ./test/utils/multiReportGenerator.js",
     "test:e2e:cd:cucumber": "wait-on && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags \"@e2e or @browser\"",
     "test:e2e:cd": "npm-run-all -p -r test:e2e:cd:cucumber && yarn run test:browser:report",
+    "test:pii": "bash ./check-logs.sh",
     "test:e2e": "cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @e2e"
 
   },

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -16,7 +16,17 @@ export TEST_HARNESS_URL=$(remove_quotes "$CFN_CICTestHarnessURL")
 export API_BASE_URL=$(remove_quotes "$CFN_CICBackEndURL")
 export SESSION_TABLE=$(remove_quotes "$CFN_CICBackendSessionTableName")
 
+declare error_code
 
 cd /app; yarn run test:e2e:cd
+error_code=$?
 
 cp -rf /app/test/reports $TEST_REPORT_ABSOLUTE_DIR
+
+sleep 2m
+
+apt-get install jq -y
+cd /app; npm run test:pii
+error_code=$?
+
+exit $error_code


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Adding PII check-logs script to scan for any PII data used in automation tests
Confirmed with Zac that we are using cicUserData.json only for automated tests.

### Why did it change

Catch PII logs before deploying.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1676](https://govukverify.atlassian.net/browse/KIWI-1676)

