### PR TITLE
KIWI-1658 - Add logic to generate report on test failure

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "check-translation": "node node_modules/@govuk-one-login/di-ipv-cri-common-express/scripts/checkTranslations.js '../../../../src/locales'",
     "test:browser:report": "node ./test/utils/multiReportGenerator.js",
     "test:e2e:cd:cucumber": "wait-on && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags \"@e2e or @browser\"",
-    "test:e2e:cd": "npm-run-all -p -r test:e2e:cd:cucumber && yarn run test:browser:report",
+    "test:e2e:cd": "npm-run-all -c test:e2e:cd:cucumber test:browser:report",
     "test:pii": "bash ./check-logs.sh",
     "test:e2e": "cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @e2e"
   },

--- a/run-tests-locally.sh
+++ b/run-tests-locally.sh
@@ -18,7 +18,7 @@ then
     eval $(awk '{ printf("export CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt)
     awk '{ printf("CFN_%s=\"%s\"\n", $1, $2) }' cf-output.txt > docker_vars.env
     echo TEST_REPORT_DIR="$TEST_REPORT_DIR" >> docker_vars.env
-    echo TEST_REPORT_ABSOLUTE_DIR="$TEST_REPORT_DIR" >> docker_vars.env
+    echo TEST_REPORT_ABSOLUTE_DIR="/$TEST_REPORT_DIR" >> docker_vars.env
     echo TEST_ENVIRONMENT="$ENVIRONMENT" >> docker_vars.env
     echo ENVIRONMENT="$ENVIRONMENT" >> docker_vars.env
     echo SAM_STACK_NAME="$SAM_STACK" >> docker_vars.env
@@ -33,7 +33,7 @@ then
     docker images $DockerImageName -q |xargs docker rmi
 
     docker build -f Dockerfile.test -t $DockerImageName .
-    docker run --rm --env-file docker_vars.env -v $(pwd)/test/reports:/results $DockerImageName
+    docker run --rm --env-file docker_vars.env -v $(pwd)/reports:/results $DockerImageName
 else    
     echo "Please ensure you've got a stack name as the first argument after ./run_tests_locally.sh..."
     echo "E.g. ./run-tests-locally.sh cic-cri-api"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -19,14 +19,19 @@ export LANGUAGE_TOGGLE_DISABLED=false
 
 declare error_code
 
+# disabling error_check to allow report generation for successful + failed tests
+set +e
 cd /app; yarn run test:e2e:cd
 error_code=$?
-
 cp -rf /app/test/reports $TEST_REPORT_ABSOLUTE_DIR
+if [ $error_code -ne 0 ]
+then
+  exit $error_code
+fi
 
 sleep 2m
 
-apt-get install jq -y
+set -eapt-get install jq -y
 cd /app; npm run test:pii
 error_code=$?
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Updated package.json scripts, run-tests.sh config so we're generating reports on failed test runs and successfully copying over to codeBuild

### Why did it change

Reports only being generated for passed FE pipeline runs

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1658](https://govukverify.atlassian.net/browse/KIWI-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[KIWI-1658]: https://govukverify.atlassian.net/browse/KIWI-1658?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ