### PR TITLE
KIWI-1808 a11y fixes

### DIFF
--- a/src/locales/cy/default.yml
+++ b/src/locales/cy/default.yml
@@ -32,7 +32,7 @@ govuk:
     cookieLinkText: "Darganfyddwch fwy am gwcis"
   phaseBanner:
     tag: beta
-    content: Mae hwn yn wasanaeth newydd – bydd eich <a href=\"https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name\" target=\"_blank\" class=\"govuk-link\" rel=\"noopener\" target=\"_blank\">adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella.
+    content: Mae hwn yn wasanaeth newydd – bydd eich <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name" target="_blank" class="govuk-link" rel="noopener" target="_blank">adborth (agor mewn tab newydd)</a> yn ein helpu i'w wella.
   languageToggle:
     ariaLabel: Dewis iaith
     englishLanguage: English

--- a/src/locales/cy/pages.errors.yml
+++ b/src/locales/cy/pages.errors.yml
@@ -16,7 +16,7 @@ pageNotFound:
     - Os ydych wedi gludo'r cyfeiriad gwe, edrychwch i weld eich bod wedi copïo'r cyfeiriad cyfan.",
     - Gallwch hefyd fynd yn ôl i'r gwasanaeth roeddech yn ceisio ei ddefnyddio a dechrau eto. Gallwch chwilio am y gwasanaeth gan ddefnyddio'ch peiriant chwilio neu dewch o hyd iddo o hafan GOV.UK.",
     - <a href=\"https://www.gov.uk/\" class=\"govuk-button\" data-module=\"govuk-button\">Ewch i hafan GOV.UK</a>",
-    - <a href=\"https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name\" target=\"_blank\" class=\"govuk-link\">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>"
+    - <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name" target="_blank" class="govuk-link">Cysylltwch â'r tîm GOV.UK One Login (agor mewn tab newydd)</a>"
 
 
 sessionEnded:

--- a/src/views/cic/enter-name.html
+++ b/src/views/cic/enter-name.html
@@ -46,6 +46,7 @@
 
     {{ hmpoText(ctx, {
         id: "surname",
+        autocomplete: "family-name",
         classes: "govuk-!-width-full"
     })}}
 

--- a/src/views/cic/enter-name.html
+++ b/src/views/cic/enter-name.html
@@ -6,6 +6,7 @@
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "hmpo-text/macro.njk" import hmpoText %}
 {% from "hmpo-form/macro.njk" import hmpoForm %}
 
@@ -27,63 +28,78 @@
 {% endset %}
 
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-three-quarters">
-      <h1 id="header" class="gov" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
-          {{ title }}
-      </h1>
-    </div>
-  </div>
-
-  {% if journeyType === "NO_PHOTO_ID" %}
-  <div id="noPhotoIdInstructions">
-    <p>{{ introText }}</p>
-    <div class="govuk-inset-text govuk-!-margin-bottom-6">
-      <p>{{ insetText1 }}</p>
-      <p>{{ insetText2 }}</p>
-    </div>
-  </div>
-  {% endif %}
+  <div>
+    <h1 id="header" class="gov" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
+        {{ title }}
+    </h1>
+    {% if journeyType === "NO_PHOTO_ID" %}
+      <div id="noPhotoIdInstructions">
+        <p>{{ introText }}</p>
+        <div class="govuk-inset-text govuk-!-margin-bottom-6">
+          <p>{{ insetText1 }}</p>
+          <p>{{ insetText2 }}</p>
+        </div>
+      </div>
+    {% endif %}
 
   {% call hmpoForm(ctx) %}
 
-  {{ hmpoText(ctx, {
-      id: "surname",
-      classes: "govuk-!-width-full"
-  })}}
-
-  <p> {{ translate("nameEntry.givenNames") }}</p>
-
-  <div class="govuk-inset-text">
-
     {{ hmpoText(ctx, {
-        id: "firstName",
-        classes: "govuk-!-width-three-quarters"
+        id: "surname",
+        classes: "govuk-!-width-full"
     })}}
 
-    {{ hmpoText(ctx, {
-        id: "middleName",
-        classes: "govuk-!-width-three-quarters"
-    })}}
+    {%- set firstNameError = hmpoGetError(ctx, {id: 'firstName'}) %}
+    {%- set middleNameError = hmpoGetError(ctx, {id: 'middleName'}) %}
 
-  </div>
+    {% if firstNameError and middleNameError %}
+        <div class="govuk-form-group govuk-form-group--error">
+    {% else %}
+        <div class="govuk-form-group ">
+      {% endif %}
 
+    {% call govukFieldset({
+      legend: {
+        text: translate("nameEntry.givenNames"),
+        classes: "govuk-!-margin-0"
+      }
+    }) %}
+        <div class="govuk-inset-text govuk-!-margin-top-2 govuk-!-padding-top-1">
+            {{ hmpoText(ctx, {
+              id: "firstName",
+              label: {
+              classes: "govuk-label"
+              },
+              classes: "govuk-input",
+              autocomplete: "given-name"
+              }) }}
 
-  <div>
+            {{ hmpoText(ctx, {
+              id: "middleName",
+              label: {
+              classes: "govuk-label"
+              },
+              classes: "govuk-input",
+              autocomplete: "additional-name"
+              }) }}
+        </div>
+      {% endcall %}
+    </div>
 
-    {{ govukDetails({
-      id: "characterDetails",
-      classes: "govuk-!-margin-bottom-7",
-      summaryText: translate("nameEntry.details.summary"),
-      html: detailsBody
-    }) }}
+    <div>
+      {{ govukDetails({
+        id: "characterDetails",
+        classes: "govuk-!-margin-bottom-7",
+        summaryText: translate("nameEntry.details.summary"),
+        html: detailsBody
+      }) }}
+    </div>
 
-  </div>
-
-  {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-name-continue-btn"}, text: translate("buttons.next")}) }}
+    {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-name-continue-btn"}, text: translate("buttons.next")}) }}
 
   {% endcall %}
 
+</div>
 {% endblock %}
 
 {# generate the specific footer items required for the PYI flows #}


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

- Remove backslashes from welsh content
- Update HTML on name page use fieldsets (matches passport CRI)
- Moves closing div to make sure that container holds whole page not just title

### Screenshots
<img width="557" alt="image" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/40401118/6586de95-a692-42f8-8d9f-8a46bdd06534">
<img width="1728" alt="Screenshot 2024-04-29 at 3 32 59 PM" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/40401118/d4e65bf4-80d5-4a3b-a0d5-af2d3912c66b">
<img width="1728" alt="Screenshot 2024-04-29 at 3 33 29 PM" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/40401118/b6e2fbe8-09ad-4394-a38f-e5b36c17434b">
<img width="1728" alt="Screenshot 2024-04-29 at 3 33 51 PM" src="https://github.com/govuk-one-login/ipv-cri-cic-front/assets/40401118/49feccc9-b523-4527-a484-a28b31312aa4">

### Why did it change

To make CIC more accessible 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1808](https://govukverify.atlassian.net/browse/KIWI-1808)



[KIWI-1808]: https://govukverify.atlassian.net/browse/KIWI-1808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ