### PR TITLE
Remove libappindicator1 from apt install

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -12,7 +12,7 @@ RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2
 RUN unzip awscliv2.zip
 RUN ./aws/install
 
-RUN apt install -y git jq openjdk-8-jdk fonts-liberation libappindicator1 procps libxkbcommon0 libgbm1
+RUN apt install -y git jq openjdk-8-jdk fonts-liberation procps libxkbcommon0 libgbm1
 
 COPY . /app
 WORKDIR /app


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Remove libappindicator1 from apt install

### Why did it change

It was causing an error and doesn't appear to be getting used
