### PR TITLE
DFC-602: Add missing analytics attributes to button

### DIFF
--- a/src/views/cic/confirm-details.html
+++ b/src/views/cic/confirm-details.html
@@ -69,11 +69,11 @@
 
     {% if (journeyType == "NO_PHOTO_ID") %}
       {% call hmpoForm(ctx) %}
-        {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-6", attributes: {"data-testid": "confirm-details-continue-btn"}, text: translate("checkDetails.noPidButtonText")}) }}
+        {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-6", attributes: {"data-testid": "confirm-details-continue-btn","data-nav":true,"data-link":"/oauth2/callback"}, text: translate("checkDetails.noPidButtonText")}) }}
       {% endcall %}
     {% else %}
       {% call hmpoForm(ctx) %}
-        {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-6", attributes: {"data-testid": "confirm-details-continue-btn"}, text: translate("checkDetails.f2fButtonText")}) }}
+        {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-6", attributes: {"data-testid": "confirm-details-continue-btn","data-nav":true,"data-link":"/oauth2/callback"}, text: translate("checkDetails.f2fButtonText")}) }}
       {% endcall %}
     {% endif %}
     </div>


### PR DESCRIPTION
### What changed
Add missing analytics attributes to button
<!-- Describe the changes in detail - the "what"-->

### Why did it change
Navigation data layer push, specifically the Inbound Button is not firing on one of the CIC CRI pages [www.review-c.account.gov.uk/confirm-details](http://www.review-c.account.gov.uk/confirm-details)
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [DFC-602](https://govukverify.atlassian.net/browse/DFC-602)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[DFC-602]: https://govukverify.atlassian.net/browse/DFC-602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ