### PR TITLE
KIWI-1863: Update CRI_START event to contain personalDataHeader

### DIFF
--- a/test/browser/support/CIC_CRI_START_SCHEMA.json
+++ b/test/browser/support/CIC_CRI_START_SCHEMA.json
@@ -39,6 +39,25 @@
         },
         "component_id": {
             "type": "string"
+        },
+        "restricted": {
+            "type": "object",
+            "properties": {
+                "device_information": {
+                    "type": "object",
+                    "properties": {
+                        "encoded": {
+                            "type": "string"
+                        }
+                    },
+                    "required": [
+                        "encoded"
+                    ]
+                }
+            },
+            "required": [
+                "device_information"
+            ]
         }
     },
     "required": [


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Update JSON schema for CRI_START event to check for personalDataHeaders

> restricted.device_information

### Why did it change

Updates required following Kiwi deployment of CloudFront changes by SRE
### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1863](https://govukverify.atlassian.net/browse/KIWI-1863)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[KIWI-1863]: https://govukverify.atlassian.net/browse/KIWI-1863?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ