### PR TITLE
IPS-732: Change DNS Records link to the cloudfront distribution

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -118,51 +118,51 @@
         "filename": "template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 115
+        "line_number": 127
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 177
+        "line_number": 199
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "b63bf00edb07af6ffba7f7ceb7ed573a913271f7",
         "is_verified": false,
-        "line_number": 557
+        "line_number": 582
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "19489ea41acf55b1e67d187515d63eb5dfe90fdb",
         "is_verified": false,
-        "line_number": 559
+        "line_number": 584
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "267255d55ef750db3ab8dbc240ecc7f57554eeea",
         "is_verified": false,
-        "line_number": 560
+        "line_number": 585
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "7584a31168b8e8f62d9b84b7b95d239b99fad815",
         "is_verified": false,
-        "line_number": 563
+        "line_number": 588
       },
       {
         "type": "Secret Keyword",
         "filename": "template.yaml",
         "hashed_secret": "42af5cf9fcf4f09147c032a0fb4877f5cf626bbc",
         "is_verified": false,
-        "line_number": 565
+        "line_number": 590
       }
     ]
   },
-  "generated_at": "2024-05-31T11:56:29Z"
+  "generated_at": "2024-05-31T04:25:59Z"
 }

--- a/template.yaml
+++ b/template.yaml
@@ -14,6 +14,13 @@ Description: >-
   CIC Front egress to CIC API's API Gateway is via a NAT Gateway which
   should have a route in the provided private subnets' route table.
 
+Metadata:
+  cfn-lint:
+    config:
+      ignore_checks:
+      - W3005
+      - W6001
+
 Parameters:
   Environment:
     Description: "The environment type"
@@ -86,6 +93,10 @@ Conditions:
   DeployAlarms: !Or
     - Condition: IsNotDevelopment
     - !Equals [!Ref DeployAlarmsInDev, true]
+  EnableCloudFront: !Or
+    - !Equals [ !Ref Environment, dev ]
+    - !Equals [ !Ref Environment, build ]
+  EnableWAFAssociation: !Equals [!Ref Environment, production]
 
 Mappings:
   PlatformConfiguration:
@@ -112,6 +123,7 @@ Mappings:
       EXTERNALWEBSITEHOST: "https://cic-cri-front.review-c.dev.account.gov.uk"
       APIBASEURL: "https://api-cic-cri-api.review-c.dev.account.gov.uk"
       DNSSUFFIX: "review-c.dev.account.gov.uk"
+      CLOUDFRONTDOMAIN: "d2mffc7h0tnarj.cloudfront.net"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       SESSIONTABLENAME: "cic-front-sessions-dev"
       GTMIDUA: "GTM-TK92W68"
@@ -129,6 +141,7 @@ Mappings:
       EXTERNALWEBSITEHOST: "https://review-c.build.account.gov.uk"
       APIBASEURL: "https://api.review-c.build.account.gov.uk"
       DNSSUFFIX: "review-c.build.account.gov.uk"
+      CLOUDFRONTDOMAIN: "d3h3ilw9ijq9hg.cloudfront.net"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       SESSIONTABLENAME: "cic-front-sessions-build"
       GTMIDUA: "GTM-TK92W68"
@@ -146,12 +159,16 @@ Mappings:
       EXTERNALWEBSITEHOST: "https://review-c.staging.account.gov.uk"
       APIBASEURL: "https://api.review-c.staging.account.gov.uk"
       DNSSUFFIX: "review-c.staging.account.gov.uk"
+      CLOUDFRONTDOMAIN: "d13b32us3mnyl9.cloudfront.net"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       SESSIONTABLENAME: "cic-front-sessions-staging"
       GTMIDUA: "GTM-TK92W68"
       GTMIDGA4: "GTM-KD86CMZ"
       GA4ENABLED: "true"
       ANALYTICSDOMAIN: "staging.account.gov.uk"
+      TESTHARNESSURL: ""
+      BACKENDURL: ""
+      BACKENDSESSIONTABLE: ""
       LOGLEVEL: "warn"
       GA4DISABLED: false
       UADISABLED: false
@@ -160,12 +177,16 @@ Mappings:
       EXTERNALWEBSITEHOST: "https://review-c.integration.account.gov.uk"
       APIBASEURL: "https://api.review-c.integration.account.gov.uk"
       DNSSUFFIX: "review-c.integration.account.gov.uk"
+      CLOUDFRONTDOMAIN: "d1jx9t5yl02x1a.cloudfront.net"
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       SESSIONTABLENAME: "cic-front-sessions-integration"
       GTMIDUA: "GTM-TK92W68"
       GTMIDGA4: "GTM-KD86CMZ"
       GA4ENABLED: "false"
       ANALYTICSDOMAIN: "integration.account.gov.uk"
+      TESTHARNESSURL: ""
+      BACKENDURL: ""
+      BACKENDSESSIONTABLE: ""
       LOGLEVEL: "warn"
       GA4DISABLED: true
       UADISABLED: false
@@ -174,12 +195,16 @@ Mappings:
       EXTERNALWEBSITEHOST: "https://review-c.account.gov.uk"
       APIBASEURL: "https://api.review-c.account.gov.uk"
       DNSSUFFIX: "review-c.account.gov.uk"
+      CLOUDFRONTDOMAIN: ""
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       SESSIONTABLENAME: "cic-front-sessions-production"
       GTMIDUA: "GTM-TT5HDKV"
       GTMIDGA4: "GTM-K4PBJH3"
       GA4ENABLED: "false"
       ANALYTICSDOMAIN: "account.gov.uk"
+      TESTHARNESSURL: ""
+      BACKENDURL: ""
+      BACKENDSESSIONTABLE: ""
       LOGLEVEL: "warn"
       GA4DISABLED: true
       UADISABLED: false
@@ -693,6 +718,7 @@ Resources:
 
   WAFv2ACLAssociation:
     Type: AWS::WAFv2::WebACLAssociation
+    Condition: EnableWAFAssociation
     Properties:
       ResourceArn: !Ref LoadBalancer
       WebACLArn: !Sub "{{resolve:ssm:/${Environment}/Platform/Security/Block/WafArn}}"
@@ -821,8 +847,12 @@ Resources:
         - DNSSUFFIX: !FindInMap [EnvironmentVariables, !Ref Environment, DNSSUFFIX]
       Type: A
       HostedZoneId: !Sub "{{resolve:ssm:/${Environment}/Platform/Route53/PrimaryZoneID}}"
-      AliasTarget:
-        DNSName: !GetAtt CICFrontCustomDomain.RegionalDomainName
+      AliasTarget: !If
+      - EnableCloudFront
+      - DNSName:  !FindInMap [EnvironmentVariables, !Ref Environment, CLOUDFRONTDOMAIN]
+        HostedZoneId: Z2FDTNDATAQYW2
+        EvaluateTargetHealth: false
+      - DNSName: !GetAtt CICFrontCustomDomain.RegionalDomainName
         HostedZoneId: !GetAtt CICFrontCustomDomain.RegionalHostedZoneId
         EvaluateTargetHealth: false
 


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed
IPS-732: Change DNS Records link to the cloudfront distribution
- This should link dns to cloudfront in CIC dev and build
- This should disable the existing WAF association in all environments other than prod.

Once this has been verified / proven to be working the the dns link will be increased to integration.

Fixed the deployment template - sorted out all of the cloudformation linting warnings / errors - put exceptions where necessary so that it lints correctly

	modified:   .secrets.baseline
	modified:   template.yaml

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [IPS-732](https://govukverify.atlassian.net/browse/IPS-732)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->


[IPS-732]: https://govukverify.atlassian.net/browse/IPS-732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ