### PR TITLE
[KIWI -1895] - CIC & IPR | Fe | Investigate drop in sonar Kiwi FE code coverage

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=alphagov_di-ipv-cri-cic-front
 sonar.organization=alphagov
 
 sonar.sources=src/
-sonar.exclusions=**/assets/**,**/*.test.js,**/lib/**,**/app.js
+sonar.exclusions=**/assets/**,**/*.test.js,**/lib/**,**/app.js,**/*/fields.js,**/*/steps.js
 
 sonar.tests=src/
 sonar.test.inclusions=**/*.test.js
@@ -10,4 +10,3 @@ sonar.test.inclusions=**/*.test.js
 sonar.sourceEncoding=UTF-8
 
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
-

--- a/src/app/cic/controllers/journeyType.test.js
+++ b/src/app/cic/controllers/journeyType.test.js
@@ -1,13 +1,13 @@
 const BaseController = require("hmpo-form-wizard").Controller;
 const { expect } = require("chai");
 const { afterEach } = require("mocha");
-const RootController = require('./root.js');
-const { API } = require("../../../lib/config");
+const JourneyTypeController = require('./journeyType.js');
+const { API } = require("../../../lib/config.js");
 
 console.log = sinon.fake();
 
-describe("RootController", () => {
-  const rootController = new RootController({ route: '/test' });
+describe("JourneyTypeController", () => {
+  const journeyTypeController = new JourneyTypeController({ route: '/test' });
   let req;
   let res;
   let next;
@@ -26,14 +26,14 @@ describe("RootController", () => {
   });
 
   it("should be an instance of BaseController", () => {
-    expect(rootController).to.be.an.instanceOf(BaseController);
+    expect(journeyTypeController).to.be.an.instanceOf(BaseController);
   });
 
   describe("saveValues", () => {
     it("should fetch the journey type from the session config endpoint", async () => {
       req.axios.get = sinon.fake.resolves({ data: { journey_type: "FACE_TO_FACE" }});
 
-      await rootController.saveValues(req, res, next);
+      await journeyTypeController.saveValues(req, res, next);
 
       sinon.assert.calledWith(
         req.axios.get,
@@ -47,10 +47,10 @@ describe("RootController", () => {
     it("should handle error if call to session config endpoint fails", async () => {
       req.axios.get = sinon.fake.rejects("Error");
 
-      await rootController.saveValues(req, res, next);
+      await journeyTypeController.saveValues(req, res, next);
 
       sinon.assert.calledWith(console.log, "Error fetching journey type");
-      sinon.assert.called(next);
+      expect(next).to.have.been.calledOnce;
     });
   });
 });

--- a/src/app/cic/fields.js
+++ b/src/app/cic/fields.js
@@ -45,3 +45,4 @@ module.exports = {
     ],
   },
 };
+


### PR DESCRIPTION
### What changed
Update sonar properties and fix unit tests for `journeyType` controller in CIC

### Why did it change
To increase code coverage

### Issue tracking
- [KIWI-1895](https://govukverify.atlassian.net/browse/KIWI-1895)

### Evidence
CIC sonar scan passing coverage threshold locally
![image](https://github.com/govuk-one-login/ipv-cri-cic-front/assets/118540036/57d3456c-0aea-4549-98c1-ed6cbb3dce06)


[KIWI-1895]: https://govukverify.atlassian.net/browse/KIWI-1895?
atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ