### PR TITLE
Kiwi | FE | Upgrade to frontend-analytics version 2.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@aws-sdk/credential-providers": "^3.438.0",
     "@aws-sdk/lib-dynamodb": "3.363.0",
     "@govuk-one-login/di-ipv-cri-common-express": "6.4.0",
-    "@govuk-one-login/frontend-analytics": "1.0.3",
+    "@govuk-one-login/frontend-analytics": "2.0.1",
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
     "ajv": "^8.12.0",


### PR DESCRIPTION
### What changed

Bump `@govuk-one-login/frontend-analytics` to v2.0.1

### Why did it change

Request from FEC to upgrade due to a new release they’ve made to fix a bug they discovered

### Issue tracking

- [KIWI-1912](https://govukverify.atlassian.net/browse/KIWI-1912)
