### PR TITLE
[KIWI-1942] Implement Low Confidence Journey with New Screens and Conditional Routing

### DIFF
--- a/src/app/cic/steps.js
+++ b/src/app/cic/steps.js
@@ -56,7 +56,6 @@ module.exports = {
     controller: nameEntry,
     next: "enter-date-birth-hmrc-check",
   },
-  // ------------------------------------------------//
   "/enter-date-birth": {
     editable: true,
     editBackStep: "confirm-details",
@@ -78,7 +77,6 @@ module.exports = {
     controller: dobEntry,
     next: "confirm-details-hmrc-check",
   },
-  // ----------------------------------------------//
   "/confirm-details": {
     controller: checkDetails,
     next: "done",
@@ -91,7 +89,6 @@ module.exports = {
     controller: checkDetails,
     next: "done",
   },
-  // ----------------------------------------------//
   "/done": {
     skip: true,
     noPost: true,

--- a/src/app/cic/steps.js
+++ b/src/app/cic/steps.js
@@ -28,6 +28,11 @@ module.exports = {
         value: "NO_PHOTO_ID",
         next: "enter-name-no-photo-id",
       },
+      {
+        field: "journeyType",
+        value: "LOW_CONFIDENCE",
+        next: "enter-name-hmrc-check",
+      },
     ],
   },
   "/enter-name": {
@@ -44,6 +49,14 @@ module.exports = {
     controller: nameEntry,
     next: "enter-date-birth-no-photo-id",
   },
+  "/enter-name-hmrc-check": {
+    editable: true,
+    editBackStep: "confirm-details",
+    fields: ["surname", "firstName", "middleName"],
+    controller: nameEntry,
+    next: "enter-date-birth-hmrc-check",
+  },
+  // ------------------------------------------------//
   "/enter-date-birth": {
     editable: true,
     editBackStep: "confirm-details",
@@ -58,6 +71,14 @@ module.exports = {
     controller: dobEntry,
     next: "confirm-details-no-photo-id",
   },
+  "/enter-date-birth-hmrc-check": {
+    editable: true,
+    editBackStep: "confirm-details",
+    fields: ["dateOfBirth"],
+    controller: dobEntry,
+    next: "confirm-details-hmrc-check",
+  },
+  // ----------------------------------------------//
   "/confirm-details": {
     controller: checkDetails,
     next: "done",
@@ -66,6 +87,11 @@ module.exports = {
     controller: checkDetails,
     next: "done",
   },
+  "/confirm-details-hmrc-check": {
+    controller: checkDetails,
+    next: "done",
+  },
+  // ----------------------------------------------//
   "/done": {
     skip: true,
     noPost: true,

--- a/src/app/cic/steps.js
+++ b/src/app/cic/steps.js
@@ -44,14 +44,14 @@ module.exports = {
   },
   "/enter-name-no-photo-id": {
     editable: true,
-    editBackStep: "confirm-details",
+    editBackStep: "confirm-details-no-photo-id",
     fields: ["surname", "firstName", "middleName"],
     controller: nameEntry,
     next: "enter-date-birth-no-photo-id",
   },
   "/enter-name-hmrc-check": {
     editable: true,
-    editBackStep: "confirm-details",
+    editBackStep: "confirm-details-hmrc-check",
     fields: ["surname", "firstName", "middleName"],
     controller: nameEntry,
     next: "enter-date-birth-hmrc-check",
@@ -65,14 +65,14 @@ module.exports = {
   },
   "/enter-date-birth-no-photo-id": {
     editable: true,
-    editBackStep: "confirm-details",
+    editBackStep: "confirm-details-no-photo-id",
     fields: ["dateOfBirth"],
     controller: dobEntry,
     next: "confirm-details-no-photo-id",
   },
   "/enter-date-birth-hmrc-check": {
     editable: true,
-    editBackStep: "confirm-details",
+    editBackStep: "confirm-details-hmrc-check",
     fields: ["dateOfBirth"],
     controller: dobEntry,
     next: "confirm-details-hmrc-check",

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -16,7 +16,7 @@ nameEntry:
     line3: "Defnyddiwch a, e, o, u in lle á, é, ó, ú. Er enghraifft, os mai Renée yw eich enw, rhowch ef fel Renee."
     line4: "Gallwch gynnwys cysylltnod neu gollnod os ydynt yn eich enw."
     line5: "Os ydych yn cael problemau wrth roi eich enw, gallwch hefyd "
-  contactSupport: 
+  contactSupport:
     text: "gysylltu â'r tîm GOV.UK One Login (agor mewn tab newydd)."
     link: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name" target="_blank" class="govuk-link" rel="noopener" target="_blank
   FACE_TO_FACE:
@@ -26,6 +26,10 @@ nameEntry:
     introText: "Mae angen i hyn fod yr union enw sydd wedi'i gofrestru i'r cyfrif. Os ydych yn defnyddio manylion cyfrif ar y cyd, nid oes angen i chi nodi enw'r person arall."
     insetText1: "Efallai y bydd yr enw ar eich cerdyn banc ond yn defnyddio llythrennau cyntaf eich enw."
     insetText2: "Gwiriwch eich ap bancio, cyfrif banc ar-lein neu gyfriflen banc ar gyfer yr enw cofrestredig llawn."
+  LOW_CONFIDENCE:
+    title: "Rhowch eich enw fel y mae'n ymddangos ar eich cofnod CThEF"
+    subtext: "Dylai gyfateb ir ffordd y dangosir eich enw ar ddogfennau fel eich slip cyflog, P60 neu lythyrau budd-daliadau."
+    validation: "Ni allwch newid eich enw a'ch dyddiad geni ar ôl i chi barhau i'r dudalen nesaf."
 
 checkDetails:
   title: "Cadarnhewch eich manylion"

--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -38,6 +38,7 @@ checkDetails:
   changeLink: "Newid"
   f2fButtonText: "Rwy'n cadarnhau bod fy manylion yn gywir"
   noPidButtonText: "Cadarnhau a pharhau"
+  lowConfidenceText: "Cadarnhau a pharhau"
 
 dateOfBirth:
   title: "Rhowch eich dyddiad geni"

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -24,7 +24,8 @@ nameEntry:
     insetText2: "Check your banking app, online bank account or bank statement for the full registered name."
   LOW_CONFIDENCE:
     title: "Enter your name as it appears on your HMRC record"
-    subtext: "It should match how your name is shown on documents such as your payslip. P60 or benefits letters."
+    subtext: "It should match how your name is shown on documents such as your payslip, P60 or benefits letters."
+    validation: "You cannot change your name and date of birth once you continue to the next page."
 
 
 checkDetails:

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -12,7 +12,7 @@ nameEntry:
     line3: "Use a, e, o, u instead of á, é, ó, ú. For example, if your name is Renée, enter it as Renee."
     line4: "You can include hyphens or apostrophes if your name has them."
     line5: "If you’re having problems entering your name, you can also "
-  contactSupport: 
+  contactSupport:
     text: "contact the GOV.UK One Login team (opens in new tab)."
     link: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name" target="_blank" class="govuk-link" rel="noopener" target="_blank
   FACE_TO_FACE:
@@ -21,7 +21,11 @@ nameEntry:
     title: "Enter your name as it appears on your bank or building society account"
     introText: "This needs to be the exact name registered to the account. If you're using joint account details, you do not need to enter the other person's name."
     insetText1: "The name on your bank card might only use your initials."
-    insetText2: "Check your banking app, online bank account or bank statement for the full registered name." 
+    insetText2: "Check your banking app, online bank account or bank statement for the full registered name."
+  LOW_CONFIDENCE:
+    title: "Enter your name as it appears on your HMRC record"
+    subtext: "It should match how your name is shown on documents such as your payslip. P60 or benefits letters."
+
 
 checkDetails:
   title: "Confirm your details"

--- a/src/locales/en/pages.yml
+++ b/src/locales/en/pages.yml
@@ -35,6 +35,7 @@ checkDetails:
   changeLink: "Change"
   f2fButtonText: "I confirm my details are correct"
   noPidButtonText: "Confirm and continue"
+  lowConfidenceText: "Confirm and continue"
 
 dateOfBirth:
   title: "Enter your date of birth"

--- a/src/views/cic/confirm-details-hmrc-check.html
+++ b/src/views/cic/confirm-details-hmrc-check.html
@@ -26,7 +26,7 @@
           actions: {
             items: [
               {
-                href: "/enter-name/edit?edit=true",
+                href: "/enter-name-hmrc-check/edit?edit=true",
                 text: translate("checkDetails.changeLink"),
                 visuallyHiddenText: translate("checkDetails.name")
               }
@@ -43,7 +43,7 @@
           actions: {
             items: [
               {
-                href: "/enter-date-birth/edit?edit=true",
+                href: "/enter-date-birth-hmrc-check/edit?edit=true",
                 text: translate("checkDetails.changeLink"),
                 visuallyHiddenText: translate("checkDetails.dateOfBirth")
               }

--- a/src/views/cic/confirm-details-hmrc-check.html
+++ b/src/views/cic/confirm-details-hmrc-check.html
@@ -1,0 +1,89 @@
+{% extends "base-form.njk" %}
+{# the content for this page is controlled by locales/en/default.yml #}
+{% set gtmJourney = "cic - checkYourDetails" %}
+{% set hmpoPageKey = "checkDetails.LOW_CONFIDENCE" %}
+
+{% from "govuk/components/header/macro.njk" import govukHeader %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
+
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds-from-desktop">
+    <h1 class="govuk-heading-l">{{ translate("checkDetails.title") }}</h1>
+
+    {{ govukSummaryList({
+      classes: 'govuk-!-margin-bottom-0',
+      rows: [
+        {
+          key: {
+            text: translate("checkDetails.name")
+          },
+          value: {
+            html: translate("{{ fullName }}")
+          },
+          actions: {
+            items: [
+              {
+                href: "/enter-name/edit?edit=true",
+                text: translate("checkDetails.changeLink"),
+                visuallyHiddenText: translate("checkDetails.name")
+              }
+            ]
+          }
+        },
+        {
+          key: {
+            text: translate("checkDetails.dateOfBirth")
+          },
+          value: {
+            html: translate("{{ formattedBirthDate }}")
+          },
+          actions: {
+            items: [
+              {
+                href: "/enter-date-birth/edit?edit=true",
+                text: translate("checkDetails.changeLink"),
+                visuallyHiddenText: translate("checkDetails.dateOfBirth")
+              }
+            ]
+          }
+        }
+      ]
+    }) }}
+
+<!--    {{ govukWarningText({-->
+<!--    text: "You can be fined up to £5,000 if you do not register.",-->
+<!--    iconFallbackText: "Warning"-->
+<!--    }) }-->
+
+      {% call hmpoForm(ctx) %}
+        {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-6", attributes: {"data-testid": "confirm-details-continue-btn","data-nav":true,"data-link":"/oauth2/callback"}, text: translate("checkDetails.f2fButtonText")}) }}
+      {% endcall %}
+    </div>
+  </div>
+
+
+{% endblock %}
+
+{# generate the specific footer items required for the PYI flows #}
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+
+{% block footer %}
+    {{ govukFooter( footerNavItems ) }}
+    <script type="text/javascript" src="/public/javascripts/all.js"></script>
+    <script {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
+      window.addEventListener('load', function () {
+        window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
+          statusCode: '200', // Access status code
+          englishPageTitle: '{{translate("checkDetails.title")}}',
+          taxonomy_level1: 'web cri', // Access taxonomy level 1
+          taxonomy_level2: 'cic', // Access taxonomy level 2
+          content_id: '003',
+          logged_in_status: true,
+          dynamic: false,
+        });
+      });
+    </script>
+{% endblock %}

--- a/src/views/cic/confirm-details-hmrc-check.html
+++ b/src/views/cic/confirm-details-hmrc-check.html
@@ -53,13 +53,13 @@
       ]
     }) }}
 
-<!--    {{ govukWarningText({-->
-<!--    text: "You can be fined up to £5,000 if you do not register.",-->
-<!--    iconFallbackText: "Warning"-->
-<!--    }) }-->
+      {{ govukWarningText({
+        text: translate("nameEntry.LOW_CONFIDENCE.validation"),
+        iconFallbackText: "Warning"
+      }) }}
 
       {% call hmpoForm(ctx) %}
-        {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-6", attributes: {"data-testid": "confirm-details-continue-btn","data-nav":true,"data-link":"/oauth2/callback"}, text: translate("checkDetails.f2fButtonText")}) }}
+        {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-6", attributes: {"data-testid": "confirm-details-continue-btn","data-nav":true,"data-link":"/oauth2/callback"}, text: translate("checkDetails.noPidButtonText")}) }}
       {% endcall %}
     </div>
   </div>

--- a/src/views/cic/confirm-details-hmrc-check.html
+++ b/src/views/cic/confirm-details-hmrc-check.html
@@ -1,7 +1,7 @@
 {% extends "base-form.njk" %}
 {# the content for this page is controlled by locales/en/default.yml #}
-{% set gtmJourney = "cic - checkYourDetails" %}
 {% set hmpoPageKey = "checkDetails.LOW_CONFIDENCE" %}
+{% set gtmJourney = "cic - checkYourDetails" %}
 
 {% from "govuk/components/header/macro.njk" import govukHeader %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
@@ -59,7 +59,7 @@
       }) }}
 
       {% call hmpoForm(ctx) %}
-        {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-6", attributes: {"data-testid": "confirm-details-continue-btn","data-nav":true,"data-link":"/oauth2/callback"}, text: translate("checkDetails.noPidButtonText")}) }}
+        {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-6", attributes: {"data-testid": "confirm-details-continue-btn","data-nav":true,"data-link":"/oauth2/callback"}, text: translate("checkDetails.lowConfidenceText")}) }}
       {% endcall %}
     </div>
   </div>

--- a/src/views/cic/confirm-details-no-photo-id.html
+++ b/src/views/cic/confirm-details-no-photo-id.html
@@ -26,7 +26,7 @@
           actions: {
             items: [
               {
-                href: "/enter-name/edit?edit=true",
+                href: "/enter-name-no-photo-id/edit?edit=true",
                 text: translate("checkDetails.changeLink"),
                 visuallyHiddenText: translate("checkDetails.name")
               }
@@ -43,7 +43,7 @@
           actions: {
             items: [
               {
-                href: "/enter-date-birth/edit?edit=true",
+                href: "/enter-date-birth-no-photo-id/edit?edit=true",
                 text: translate("checkDetails.changeLink"),
                 visuallyHiddenText: translate("checkDetails.dateOfBirth")
               }

--- a/src/views/cic/enter-date-birth-hmrc-check.html
+++ b/src/views/cic/enter-date-birth-hmrc-check.html
@@ -1,0 +1,60 @@
+{% extends "base-form.njk" %}
+{# the content for this page is controlled by locales/en/default.yml #}
+{% set hmpoPageKey = "dateOfBirth.LOW_CONFIDENCE" %}
+{% set gtmJourney = "cic - dateOfBirth" %}
+
+{% from "hmpo-text/macro.njk" import hmpoText %}
+{% from "hmpo-form/macro.njk" import hmpoForm %}
+{% from "hmpo-date/macro.njk" import hmpoDate %}
+
+
+{% block mainContent %}
+
+{% set legendContent = translate("dateOfBirth.formLegend") %}
+{% set introductoryCopy = translate("dateOfBirth.dobInformationContext") %}
+{% set hintText = translate("dateOfBirth.hintText") %}
+{% set formInstructions = "<p class=\"govuk-hint\">"+hintText+"</p>" %}
+
+{% call hmpoForm(ctx) %}
+{{ hmpoDate(ctx, {
+    id: "dateOfBirth",
+    namePrefix: "dateOfBirth",
+      fieldset: {
+        legend: {
+            text: legendContent,
+            isPageHeading: true,
+            classes: "govuk-fieldset__legend--l"
+    }
+},
+hint: {
+html: formInstructions
+}
+}) }}
+
+
+{{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-dob-continue-btn"}, text: translate("buttons.next")}) }}
+
+{% endcall %}
+
+{% endblock %}
+
+{# generate the specific footer items required for the PYI flows #}
+{% set footerNavItems = translate("govuk.footerNavItems") %}
+
+{% block footer %}
+{{ govukFooter( footerNavItems ) }}
+<script type="text/javascript" src="/public/javascripts/all.js"></script>
+  <script {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
+    window.addEventListener('load', function () {
+      window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
+        statusCode: '200', // Access status code
+        englishPageTitle: '{{translate("dateOfBirth.title")}}',
+        taxonomy_level1: 'web cri', // Access taxonomy level 1
+        taxonomy_level2: 'cic', // Access taxonomy level 2
+        content_id: '002',
+        logged_in_status: true,
+        dynamic: false,
+      });
+    });
+  </script>
+{% endblock %}

--- a/src/views/cic/enter-name-hmrc-check.html
+++ b/src/views/cic/enter-name-hmrc-check.html
@@ -2,7 +2,7 @@
 {# the content for this page is controlled by locales/en/default.yml #}
 {% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% set gtmJourney = "cic - nameEntry" %}
-{% set hmpoPageKey = "nameEntry.FACE_TO_FACE" %}
+{% set hmpoPageKey = "nameEntry.LOW_CONFIDENCE" %}
 
 {% from "govuk/components/inset-text/macro.njk" import govukInsetText %}
 {% from "govuk/components/header/macro.njk" import govukHeader %}
@@ -34,7 +34,12 @@
         {{ title }}
     </h1>
 
-  {% call hmpoForm(ctx) %}
+    <div>
+      <p>It should match how your name is shown on documents such as your payslip, P60 or benefits letters.</p>
+    </div>
+
+
+    {% call hmpoForm(ctx) %}
 
     {{ hmpoText(ctx, {
         id: "surname",

--- a/src/views/cic/enter-name-hmrc-check.html
+++ b/src/views/cic/enter-name-hmrc-check.html
@@ -42,80 +42,85 @@
     {% call hmpoForm(ctx) %}
 
     {{ hmpoText(ctx, {
-        id: "surname",
-        autocomplete: "family-name",
-        classes: "govuk-!-width-full"
+    id: "surname",
+    autocomplete: "family-name",
+    classes: "govuk-!-width-full"
     })}}
 
     {%- set firstNameError = hmpoGetError(ctx, {id: 'firstName'}) %}
     {%- set middleNameError = hmpoGetError(ctx, {id: 'middleName'}) %}
 
     {% if firstNameError and middleNameError %}
-        <div class="govuk-form-group govuk-form-group--error">
-    {% else %}
-        <div class="govuk-form-group ">
-      {% endif %}
+    <div class="govuk-form-group govuk-form-group--error">
+      {% else %}
+      <div class="govuk-form-group ">
+        {% endif %}
 
-    {% call govukFieldset({
-      legend: {
+        {% call govukFieldset({
+        legend: {
         text: translate("nameEntry.givenNames"),
         classes: "govuk-!-margin-0"
-      }
-    }) %}
+        }
+        }) %}
         <div class="govuk-inset-text govuk-!-margin-top-2 govuk-!-padding-top-1">
-            {{ hmpoText(ctx, {
-              id: "firstName",
-              label: {
-              classes: "govuk-label"
-              },
-              classes: "govuk-input",
-              autocomplete: "given-name"
-              }) }}
+          {{ hmpoText(ctx, {
+          id: "firstName",
+          label: {
+          classes: "govuk-label"
+          },
+          classes: "govuk-input",
+          autocomplete: "given-name"
+          }) }}
 
-            {{ hmpoText(ctx, {
-              id: "middleName",
-              label: {
-              classes: "govuk-label"
-              },
-              classes: "govuk-input",
-              autocomplete: "additional-name"
-              }) }}
+          {{ hmpoText(ctx, {
+          id: "middleName",
+          label: {
+          classes: "govuk-label"
+          },
+          classes: "govuk-input",
+          autocomplete: "additional-name"
+          }) }}
         </div>
+        {% endcall %}
+      </div>
+
+      <div>
+        {{ govukDetails({
+        id: "characterDetails",
+        classes: "govuk-!-margin-bottom-7",
+        summaryText: translate("nameEntry.details.summary"),
+        html: detailsBody
+        }) }}
+      </div>
+
+      {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-name-continue-btn"}, text: translate("buttons.next")}) }}
+
       {% endcall %}
+
+      <p class="govuk-body">
+        <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name%22" class="govuk-link" rel="noreferrer noopener" target="_blank">Contact the GOV.UK One Login team (opens in a new tab)</a>
+      </p>
+
     </div>
+    {% endblock %}
 
+    {# generate the specific footer items required for the PYI flows #}
+    {% set footerNavItems = translate("govuk.footerNavItems") %}
 
-    {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-name-continue-btn"}, text: translate("buttons.next")}) }}
-          <div>
-            {{ govukDetails({
-            id: "characterDetails",
-            classes: "govuk-!-margin-bottom-7",
-            summaryText: translate("nameEntry.details.summary"),
-            html: detailsBody
-            }) }}
-          </div>
-  {% endcall %}
-
-</div>
-{% endblock %}
-
-{# generate the specific footer items required for the PYI flows #}
-{% set footerNavItems = translate("govuk.footerNavItems") %}
-
-{% block footer %}
-  {{ govukFooter( footerNavItems ) }}
-  <script type="text/javascript" src="/public/javascripts/all.js"></script>
-  <script {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
-    window.addEventListener('load', function () {
-      window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
-        statusCode: '200', // Access status code
-        englishPageTitle: '{{translate("nameEntry.title")}}',
-        taxonomy_level1: 'web cri', // Access taxonomy level 1
-        taxonomy_level2: 'cic', // Access taxonomy level 2
-        content_id: '001',
-        logged_in_status: true,
-        dynamic: false,
+    {% block footer %}
+    {{ govukFooter( footerNavItems ) }}
+    <script type="text/javascript" src="/public/javascripts/all.js"></script>
+    <script {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
+      window.addEventListener('load', function () {
+        window.DI.analyticsGa4.pageViewTracker.trackOnPageLoad({
+          statusCode: '200', // Access status code
+          englishPageTitle: '{{translate("nameEntry.title")}}',
+          taxonomy_level1: 'web cri', // Access taxonomy level 1
+          taxonomy_level2: 'cic', // Access taxonomy level 2
+          content_id: '001',
+          logged_in_status: true,
+          dynamic: false,
+        });
       });
-    });
-  </script>
-{% endblock %}
+    </script>
+    {% endblock %}

--- a/src/views/cic/enter-name-hmrc-check.html
+++ b/src/views/cic/enter-name-hmrc-check.html
@@ -98,9 +98,7 @@
       {% endcall %}
 
       <div>
-        <p class="govuk-body">
-          <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name%22" class="govuk-link" rel="noreferrer noopener" target="_blank">text: translate("nameEntry.contactSupport.text")</a>
-        </p>
+        <p><a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name-hmrc-check\" class="govuk-link" rel="noreferrer noopener" target="_blank">{{ translate("error.unrecoverable.contactMeLink") }}</a></p>
       </div>
 
     </div>

--- a/src/views/cic/enter-name-hmrc-check.html
+++ b/src/views/cic/enter-name-hmrc-check.html
@@ -34,8 +34,8 @@
         {{ title }}
     </h1>
 
-    <div>
-      <p>It should match how your name is shown on documents such as your payslip, P60 or benefits letters.</p>
+    <div id="lowConfidenceSubtext">
+      <p>{{ translate("nameEntry.LOW_CONFIDENCE.subtext") }}</p>
     </div>
 
 

--- a/src/views/cic/enter-name-hmrc-check.html
+++ b/src/views/cic/enter-name-hmrc-check.html
@@ -97,9 +97,11 @@
 
       {% endcall %}
 
-      <p class="govuk-body">
-        <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name%22" class="govuk-link" rel="noreferrer noopener" target="_blank">Contact the GOV.UK One Login team (opens in a new tab)</a>
-      </p>
+      <div>
+        <p class="govuk-body">
+          <a href="https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name%22" class="govuk-link" rel="noreferrer noopener" target="_blank">text: translate("nameEntry.contactSupport.text")</a>
+        </p>
+      </div>
 
     </div>
     {% endblock %}

--- a/src/views/cic/enter-name.html
+++ b/src/views/cic/enter-name.html
@@ -1,6 +1,5 @@
 {% extends "base-form.njk" %}
 {# the content for this page is controlled by locales/en/default.yml #}
-{% from "govuk/components/warning-text/macro.njk" import govukWarningText %}
 {% set gtmJourney = "cic - nameEntry" %}
 {% set hmpoPageKey = "nameEntry.FACE_TO_FACE" %}
 
@@ -13,91 +12,91 @@
 
 {% block mainContent %}
 
-
 {% set detailsBody %}
 <div>
   <p>{{ translate("nameEntry.details.line1") }}</p>
-    <ul class="govuk-list govuk-list--bullet">
-      <li class="govuk-!-margin-left-3">{{ translate("nameEntry.details.bullet1") }}</li>
-      <li class="govuk-!-margin-left-3">{{ translate("nameEntry.details.bullet2") }}</li>
-    </ul>
-    <p>{{ translate("nameEntry.details.line2") }}</p>
-    <p>{{ translate("nameEntry.details.line3") }}</p>
-    <p>{{ translate("nameEntry.details.line4") }}</p>
-    <p>{{ translate("nameEntry.details.line5") }}<a href={{ "nameEntry.contactSupport.link" | translate }} id="contactSupport"> {{ "nameEntry.contactSupport.text" | translate }}</a></p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li class="govuk-!-margin-left-3">{{ translate("nameEntry.details.bullet1") }}</li>
+    <li class="govuk-!-margin-left-3">{{ translate("nameEntry.details.bullet2") }}</li>
+  </ul>
+  <p>{{ translate("nameEntry.details.line2") }}</p>
+  <p>{{ translate("nameEntry.details.line3") }}</p>
+  <p>{{ translate("nameEntry.details.line4") }}</p>
+  <p>{{ translate("nameEntry.details.line5") }}<a href={{ "nameEntry.contactSupport.link" | translate }} id="contactSupport"> {{ "nameEntry.contactSupport.text" | translate }}</a></p>
 </div>
 {% endset %}
 
 
-  <div>
-    <h1 id="header" class="gov" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
-        {{ title }}
-    </h1>
+<div>
+  <h1 id="header" class="gov" data-page="{{hmpoPageKey}}" class="govuk-heading-l">
+    {{ title }}
+  </h1>
 
   {% call hmpoForm(ctx) %}
 
-    {{ hmpoText(ctx, {
-        id: "surname",
-        autocomplete: "family-name",
-        classes: "govuk-!-width-full"
-    })}}
+  {{ hmpoText(ctx, {
+  id: "surname",
+  autocomplete: "family-name",
+  classes: "govuk-!-width-full"
+  })}}
 
-    {%- set firstNameError = hmpoGetError(ctx, {id: 'firstName'}) %}
-    {%- set middleNameError = hmpoGetError(ctx, {id: 'middleName'}) %}
+  {%- set firstNameError = hmpoGetError(ctx, {id: 'firstName'}) %}
+  {%- set middleNameError = hmpoGetError(ctx, {id: 'middleName'}) %}
 
-    {% if firstNameError and middleNameError %}
-        <div class="govuk-form-group govuk-form-group--error">
+  {% if firstNameError and middleNameError %}
+  <div class="govuk-form-group govuk-form-group--error">
     {% else %}
-        <div class="govuk-form-group ">
+    <div class="govuk-form-group ">
       {% endif %}
 
-    {% call govukFieldset({
+      {% call govukFieldset({
       legend: {
-        text: translate("nameEntry.givenNames"),
-        classes: "govuk-!-margin-0"
+      text: translate("nameEntry.givenNames"),
+      classes: "govuk-!-margin-0"
       }
-    }) %}
-        <div class="govuk-inset-text govuk-!-margin-top-2 govuk-!-padding-top-1">
-            {{ hmpoText(ctx, {
-              id: "firstName",
-              label: {
-              classes: "govuk-label"
-              },
-              classes: "govuk-input",
-              autocomplete: "given-name"
-              }) }}
+      }) %}
+      <div class="govuk-inset-text govuk-!-margin-top-2 govuk-!-padding-top-1">
+        {{ hmpoText(ctx, {
+        id: "firstName",
+        label: {
+        classes: "govuk-label"
+        },
+        classes: "govuk-input",
+        autocomplete: "given-name"
+        }) }}
 
-            {{ hmpoText(ctx, {
-              id: "middleName",
-              label: {
-              classes: "govuk-label"
-              },
-              classes: "govuk-input",
-              autocomplete: "additional-name"
-              }) }}
-        </div>
+        {{ hmpoText(ctx, {
+        id: "middleName",
+        label: {
+        classes: "govuk-label"
+        },
+        classes: "govuk-input",
+        autocomplete: "additional-name"
+        }) }}
+      </div>
       {% endcall %}
     </div>
 
+    <div>
+      {{ govukDetails({
+      id: "characterDetails",
+      classes: "govuk-!-margin-bottom-7",
+      summaryText: translate("nameEntry.details.summary"),
+      html: detailsBody
+      }) }}
+    </div>
 
     {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-name-continue-btn"}, text: translate("buttons.next")}) }}
-          <div>
-            {{ govukDetails({
-            id: "characterDetails",
-            classes: "govuk-!-margin-bottom-7",
-            summaryText: translate("nameEntry.details.summary"),
-            html: detailsBody
-            }) }}
-          </div>
-  {% endcall %}
 
-</div>
-{% endblock %}
+    {% endcall %}
 
-{# generate the specific footer items required for the PYI flows #}
-{% set footerNavItems = translate("govuk.footerNavItems") %}
+  </div>
+  {% endblock %}
 
-{% block footer %}
+  {# generate the specific footer items required for the PYI flows #}
+  {% set footerNavItems = translate("govuk.footerNavItems") %}
+
+  {% block footer %}
   {{ govukFooter( footerNavItems ) }}
   <script type="text/javascript" src="/public/javascripts/all.js"></script>
   <script {% if cspNonce %} nonce="{{ cspNonce }}"{%  endif %}>
@@ -113,4 +112,4 @@
       });
     });
   </script>
-{% endblock %}
+  {% endblock %}


### PR DESCRIPTION
## Proposed changes

- Create a new Name Entry screen specific to the Low Confidence Journey
- Create a new dateOfBirth screen specific to the Low Confidence Journey
- Create a new checkYourDetails screen specific to the Low Confidence Journey
- Add conditional routing to the CIC root controller and journey steps file to direct users to the correct sequence of screens depending on the CIC use case
- Fix Low_Confidence & noPID routing issues 
- Add Welsh copy for the new screens

## Evidence

<img width="480" alt="enter-name-hmrc-check English" src="https://github.com/user-attachments/assets/84e3999d-e011-49b7-8bed-382fb58927de">


<img width="480" alt="enter-name-hmrc-check Cy" src="https://github.com/user-attachments/assets/cb33569c-46e3-4180-b153-65dde7b2f237">

<img width="480" alt="confirm-details-hmrc-check English" src="https://github.com/user-attachments/assets/da65e158-8bf5-4ba6-8c16-437c67b6a9d4">

<img width="480" alt="confirm-details-hmrc-check Cy" src="https://github.com/user-attachments/assets/f2d442c6-3812-4907-bec1-3d9c68eb0744">

