### PR TITLE
KIWI-1986 CIC | FE | Incorrect Page Titles in Staging

### DIFF
--- a/src/locales/cy/pages.yml
+++ b/src/locales/cy/pages.yml
@@ -19,14 +19,14 @@ nameEntry:
   contactSupport:
     text: "gysylltu â'r tîm GOV.UK One Login (agor mewn tab newydd)."
     link: https://home.account.gov.uk/contact-gov-uk-one-login?fromURL=https://www.review-c.account.gov.uk/enter-name" target="_blank" class="govuk-link" rel="noopener" target="_blank
-  FACE_TO_FACE:
+  f2f:
     title: "Rhowch eich enw yn union fel y mae'n ymddangos ar eich ID gyda llun"
-  NO_PHOTO_ID:
+  bank_account:
     title: "Rhowch eich enw fel y mae'n ymddangos ar eich cyfrif banc neu gymdeithas adeiladu"
     introText: "Mae angen i hyn fod yr union enw sydd wedi'i gofrestru i'r cyfrif. Os ydych yn defnyddio manylion cyfrif ar y cyd, nid oes angen i chi nodi enw'r person arall."
     insetText1: "Efallai y bydd yr enw ar eich cerdyn banc ond yn defnyddio llythrennau cyntaf eich enw."
     insetText2: "Gwiriwch eich ap bancio, cyfrif banc ar-lein neu gyfriflen banc ar gyfer yr enw cofrestredig llawn."
-  LOW_CONFIDENCE:
+  hmrc_check:
     title: "Rhowch eich enw fel y mae'n ymddangos ar eich cofnod CThEF"
     subtext: "Dylai gyfateb ir ffordd y dangosir eich enw ar ddogfennau fel eich slip cyflog, P60 neu lythyrau budd-daliadau."
     validation: "Ni allwch newid eich enw a'ch dyddiad geni ar ôl i chi barhau i'r dudalen nesaf."

--- a/src/views/cic/confirm-details-hmrc-check.html
+++ b/src/views/cic/confirm-details-hmrc-check.html
@@ -1,6 +1,6 @@
 {% extends "base-form.njk" %}
 {# the content for this page is controlled by locales/en/default.yml #}
-{% set hmpoPageKey = "checkDetails.hmrc_check" %}
+{% set hmpoPageKey = "checkDetails" %}
 {% set gtmJourney = "cic - checkYourDetails" %}
 
 {% from "govuk/components/header/macro.njk" import govukHeader %}

--- a/src/views/cic/confirm-details-no-photo-id.html
+++ b/src/views/cic/confirm-details-no-photo-id.html
@@ -1,6 +1,6 @@
 {% extends "base-form.njk" %}
 {# the content for this page is controlled by locales/en/default.yml #}
-{% set hmpoPageKey = "checkDetails.bank_account" %}
+{% set hmpoPageKey = "checkDetails" %}
 {% set gtmJourney = "cic - checkYourDetails" %}
 
 {% from "govuk/components/header/macro.njk" import govukHeader %}

--- a/src/views/cic/confirm-details.html
+++ b/src/views/cic/confirm-details.html
@@ -1,6 +1,6 @@
 {% extends "base-form.njk" %}
 {# the content for this page is controlled by locales/en/default.yml #}
-{% set hmpoPageKey = "checkDetails.f2f" %}
+{% set hmpoPageKey = "checkDetails" %}
 {% set gtmJourney = "cic - checkYourDetails" %}
 
 {% from "govuk/components/header/macro.njk" import govukHeader %}

--- a/src/views/cic/enter-date-birth-hmrc-check.html
+++ b/src/views/cic/enter-date-birth-hmrc-check.html
@@ -1,6 +1,6 @@
 {% extends "base-form.njk" %}
 {# the content for this page is controlled by locales/en/default.yml #}
-{% set hmpoPageKey = "dateOfBirth.hmrc_check" %}
+{% set hmpoPageKey = "dateOfBirth" %}
 {% set gtmJourney = "cic - dateOfBirth" %}
 
 {% from "hmpo-text/macro.njk" import hmpoText %}

--- a/src/views/cic/enter-date-birth-no-photo-id.html
+++ b/src/views/cic/enter-date-birth-no-photo-id.html
@@ -1,6 +1,6 @@
 {% extends "base-form.njk" %}
 {# the content for this page is controlled by locales/en/default.yml #}
-{% set hmpoPageKey = "dateOfBirth.bank_account" %}
+{% set hmpoPageKey = "dateOfBirth" %}
 {% set gtmJourney = "cic - dateOfBirth" %}
 
 {% from "hmpo-text/macro.njk" import hmpoText %}

--- a/src/views/cic/enter-date-birth.html
+++ b/src/views/cic/enter-date-birth.html
@@ -1,6 +1,6 @@
 {% extends "base-form.njk" %}
 {# the content for this page is controlled by locales/en/default.yml #}
-{% set hmpoPageKey = "dateOfBirth.f2f" %}
+{% set hmpoPageKey = "dateOfBirth" %}
 {% set gtmJourney = "cic - dateOfBirth" %}
 
 {% from "hmpo-text/macro.njk" import hmpoText %}


### PR DESCRIPTION
### What changed

Removed journey type from hmpoPageKey as this was preventing DOB and check details pages accessing the copy in the yaml files. This copy in particular was not conditional based on journey type so the suffixes weren't necessary

### Why did it change

To show the page title correctly on browser tabs

### Issue tracking

- [KIWI-1986](https://govukverify.atlassian.net/browse/KIWI-1986)

![Screenshot 2024-09-27 at 11 53 39](https://github.com/user-attachments/assets/04106b7d-2add-4564-8c7c-a5d5ccab58dd)
![Screenshot 2024-09-27 at 11 53 50](https://github.com/user-attachments/assets/c1f7811e-fbc8-4a4a-b5c7-2e35e12f57e1)
![Screenshot 2024-09-27 at 11 54 02](https://github.com/user-attachments/assets/effcc71d-5e37-4479-b206-29b4e01c071e)
![Screenshot 2024-09-27 at 11 54 14](https://github.com/user-attachments/assets/1ea11890-0109-4187-b800-08b2c82008e8)




[KIWI-1986]: https://govukverify.atlassian.net/browse/KIWI-1986?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ