### PR TITLE
KIWI-2061: Updated govuk frontend for the crown copyright change 4.8 -> 4.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "express": "4.18.2",
     "express-async-errors": "3.1.1",
     "express-session": "^1.17.3",
-    "govuk-frontend": "4.8.0",
+    "govuk-frontend": "4.9.0",
     "hmpo-app": "3.0.1",
     "hmpo-components": "6.4.0",
     "hmpo-config": "3.0.0",


### PR DESCRIPTION
### What changed

Updated gov uk frontend

### Why did it change

To update crown copyright logo in the footer

