### PR TITLE
[KIWI-2029] Add Max Length validation to fields

### DIFF
--- a/src/app/cic/fields.js
+++ b/src/app/cic/fields.js
@@ -5,6 +5,7 @@ module.exports = {
     validate: [
       "required",
       { type: "minlength", arguments: 2 },
+      { type: "maxlength", arguments: 40 },
       {
         type: "regexNumbersOrSpecialCharacters",
         fn: (value) => value.match(/^[A-Za-z .'-]*$/),
@@ -17,6 +18,7 @@ module.exports = {
     validate: [
       "required",
       { type: "minlength", arguments: 2 },
+      { type: "maxlength", arguments: 40 },
       {
         type: "regexNumbersOrSpecialCharacters",
         fn: (value) => value.match(/^[A-Za-z .'-]*$/),
@@ -28,6 +30,7 @@ module.exports = {
     journeyKey: "middleName",
     validate: [
       { type: "minlength", arguments: 2 },
+      { type: "maxlength", arguments: 40 },
       {
         type: "regexNumbersOrSpecialCharacters",
         fn: (value) => value.match(/^[A-Za-z .'-]*$/),
@@ -40,6 +43,7 @@ module.exports = {
     validate: [
       "required",
       "date",
+      { type: "maxlength", arguments: 18 },
       { type: "before", arguments: [] },
       { type: "after", arguments: ["1904-02-12"] },
     ],

--- a/src/app/cic/fields.test.js
+++ b/src/app/cic/fields.test.js
@@ -1,0 +1,108 @@
+const { expect } = require("chai");
+const fields = require("./fields");
+
+describe("Field Validation", () => {
+  const testFieldLength = (fieldConfig, value, errorMessage) => {
+    const maxLengthRule = fieldConfig.validate.find(
+      (rule) => rule.type === "maxlength",
+    );
+    const isValid = value.length <= maxLengthRule.arguments;
+
+    expect(
+      isValid,
+      `${errorMessage}. Expected length to be less than ${maxLengthRule.arguments}, but got ${value.length}`,
+    ).to.be.false;
+  };
+
+  const testNameField = (fieldName, fieldConfig) => {
+    describe(`${fieldName}`, () => {
+      it("should accept valid names", () => {
+        const validNames = ["Smith", "O'Connor", "Van der Berg", "Smith-Jones"];
+        validNames.forEach((name) => {
+          const validationResults = fieldConfig.validate
+            .filter((rule) => typeof rule === "object")
+            .every((rule) => {
+              if (rule.type === "minlength")
+                return name.length >= rule.arguments;
+              if (rule.type === "maxlength")
+                return name.length <= rule.arguments;
+              if (rule.type === "regexNumbersOrSpecialCharacters")
+                return rule.fn(name);
+              return true;
+            });
+          expect(validationResults).to.be.true;
+        });
+      });
+
+      it("should reject names that are too short", () => {
+        const name = "A";
+        const minLengthRule = fieldConfig.validate.find(
+          (rule) => rule.type === "minlength",
+        );
+        expect(
+          name.length >= minLengthRule.arguments,
+          `Name '${name}' is too short. Minimum length is ${minLengthRule.arguments}`,
+        ).to.be.false;
+      });
+
+      it("should reject names that are too long", () => {
+        const name = "A".repeat(41);
+        testFieldLength(
+          fieldConfig,
+          name,
+          `${fieldName} exceeds maximum allowed length`,
+        );
+      });
+
+      it("should reject names with invalid characters", () => {
+        const invalidNames = ["John123", "Mary#Smith", "Test@Name", "12345"];
+        invalidNames.forEach((name) => {
+          const regexRule = fieldConfig.validate.find(
+            (rule) => rule.type === "regexNumbersOrSpecialCharacters",
+          );
+          expect(
+            regexRule.fn(name),
+            `Name '${name}' contains invalid characters. Only letters, spaces, hyphens, and apostrophes are allowed`,
+          ).to.be.null;
+        });
+      });
+    });
+  };
+
+  // Test all name fields
+  const nameFields = {
+    surname: fields.surname,
+    firstName: fields.firstName,
+    middleName: fields.middleName,
+  };
+
+  Object.entries(nameFields).forEach(([fieldName, config]) => {
+    testNameField(fieldName, config);
+  });
+
+  describe("Date of Birth", () => {
+    const { dateOfBirth } = fields;
+
+    it("should accept valid date formats", () => {
+      const validDates = ["1990-01-01", "2000-12-31"];
+      validDates.forEach((date) => {
+        const maxLengthRule = dateOfBirth.validate.find(
+          (rule) => rule.type === "maxlength",
+        );
+        expect(
+          date.length <= maxLengthRule.arguments,
+          `Date '${date}' is not a valid date format`,
+        ).to.be.true;
+      });
+    });
+
+    it("should reject dates that are too long", () => {
+      const date = "1990-01-01T00:00:00Z";
+      testFieldLength(
+        dateOfBirth,
+        date,
+        "Date string exceeds maximum allowed length",
+      );
+    });
+  });
+});

--- a/src/app/cic/fields.test.js
+++ b/src/app/cic/fields.test.js
@@ -1,7 +1,7 @@
 const { expect } = require("chai");
 const fields = require("./fields");
 
-describe("Field Validation", () => {
+describe("Fields maxLength ", () => {
   const testFieldLength = (fieldConfig, value, errorMessage) => {
     const maxLengthRule = fieldConfig.validate.find(
       (rule) => rule.type === "maxlength",
@@ -16,36 +16,7 @@ describe("Field Validation", () => {
 
   const testNameField = (fieldName, fieldConfig) => {
     describe(`${fieldName}`, () => {
-      it("should accept valid names", () => {
-        const validNames = ["Smith", "O'Connor", "Van der Berg", "Smith-Jones"];
-        validNames.forEach((name) => {
-          const validationResults = fieldConfig.validate
-            .filter((rule) => typeof rule === "object")
-            .every((rule) => {
-              if (rule.type === "minlength")
-                return name.length >= rule.arguments;
-              if (rule.type === "maxlength")
-                return name.length <= rule.arguments;
-              if (rule.type === "regexNumbersOrSpecialCharacters")
-                return rule.fn(name);
-              return true;
-            });
-          expect(validationResults).to.be.true;
-        });
-      });
-
-      it("should reject names that are too short", () => {
-        const name = "A";
-        const minLengthRule = fieldConfig.validate.find(
-          (rule) => rule.type === "minlength",
-        );
-        expect(
-          name.length >= minLengthRule.arguments,
-          `Name '${name}' is too short. Minimum length is ${minLengthRule.arguments}`,
-        ).to.be.false;
-      });
-
-      it("should reject names that are too long", () => {
+      it("should reject names that exceed the maximum length", () => {
         const name = "A".repeat(41);
         testFieldLength(
           fieldConfig,
@@ -53,23 +24,9 @@ describe("Field Validation", () => {
           `${fieldName} exceeds maximum allowed length`,
         );
       });
-
-      it("should reject names with invalid characters", () => {
-        const invalidNames = ["John123", "Mary#Smith", "Test@Name", "12345"];
-        invalidNames.forEach((name) => {
-          const regexRule = fieldConfig.validate.find(
-            (rule) => rule.type === "regexNumbersOrSpecialCharacters",
-          );
-          expect(
-            regexRule.fn(name),
-            `Name '${name}' contains invalid characters. Only letters, spaces, hyphens, and apostrophes are allowed`,
-          ).to.be.null;
-        });
-      });
     });
   };
 
-  // Test all name fields
   const nameFields = {
     surname: fields.surname,
     firstName: fields.firstName,
@@ -83,20 +40,7 @@ describe("Field Validation", () => {
   describe("Date of Birth", () => {
     const { dateOfBirth } = fields;
 
-    it("should accept valid date formats", () => {
-      const validDates = ["1990-01-01", "2000-12-31"];
-      validDates.forEach((date) => {
-        const maxLengthRule = dateOfBirth.validate.find(
-          (rule) => rule.type === "maxlength",
-        );
-        expect(
-          date.length <= maxLengthRule.arguments,
-          `Date '${date}' is not a valid date format`,
-        ).to.be.true;
-      });
-    });
-
-    it("should reject dates that are too long", () => {
+    it("should reject dates that exceed the maximum length", () => {
       const date = "1990-01-01T00:00:00Z";
       testFieldLength(
         dateOfBirth,


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->
[KIWI-2029] Add Max Length validation to fields

### What changed

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXXX)

## Evidence

<img width="600" alt="Screenshot 2024-12-31 at 12 18 59" src="https://github.com/user-attachments/assets/2a53c04c-e2c4-4254-90fb-3166e7a9b0db" />






[KIWI-2029]: https://govukverify.atlassian.net/browse/KIWI-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ