### PR TITLE
[KIWI-2172] - fix to incorrect GA4 naming

### DIFF
--- a/src/lib/locals.js
+++ b/src/lib/locals.js
@@ -6,18 +6,18 @@ module.exports = {
     ga4ContainerId,
     uaContainerId,
     analyticsCookieDomain,
-    isGa4Enabled,
+    ga4Enabled,
   }) => {
-    app.set("APP.GTM.GOOGLE_ANALYTICS_4_GTM_CONTAINER_ID", ga4ContainerId);
+    app.set("APP.GTM.GA4_ID", ga4ContainerId);
     app.set("APP.GTM.UA_ID", uaContainerId);
-    app.set("APP.GTM.IS_GA4_ENABLED", isGa4Enabled);
+    app.set("APP.GTM.GA4_ENABLED", ga4Enabled);
     app.set("APP.GTM.ANALYTICS_COOKIE_DOMAIN", analyticsCookieDomain);
   },
 
   getGTM: function (req, res, next) {
     res.locals.ga4ContainerId = req.app.get("APP.GTM.GA4_ID");
     res.locals.uaContainerId = req.app.get("APP.GTM.UA_ID");
-    res.locals.isGa4Enabled = req.app.get("APP.GTM.IS_GA4_ENABLED");
+    res.locals.ga4Enabled = req.app.get("APP.GTM.GA4_ENABLED");
     res.locals.analyticsCookieDomain = req.app.get(
       "APP.GTM.ANALYTICS_COOKIE_DOMAIN",
     );


### PR DESCRIPTION
- [KIWI-2172](https://govukverify.atlassian.net/browse/KIWI-2172)




[KIWI-2172]: https://govukverify.atlassian.net/browse/KIWI-2172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ