### PR TITLE
[KIWI-2012] -  | CM | Remove blocking from node eventloop 

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -29,6 +29,7 @@ const steps = require("./app/cic/steps");
 const fields = require("./app/cic/fields");
 
 const {
+  PACKAGE_NAME,
   API,
   APP,
   PORT,
@@ -163,7 +164,7 @@ router.use(wizard(steps, fields, wizardOptions));
 
 router.use((err, req, res, next) => {
   logger
-    .get()
+    .get(PACKAGE_NAME)
     .error(
       "Error caught by Express handler - redirecting to Callback with server_error",
       { err },

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -1,6 +1,7 @@
 require("dotenv").config();
 
 module.exports = {
+  PACKAGE_NAME: "di-ipv-cri-cic-front",
   API: {
     BASE_URL:
       process.env.API_BASE_URL ||

--- a/template.yaml
+++ b/template.yaml
@@ -994,7 +994,7 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorAlarm"
-      AlarmDescription: !Sub "Trigger the warning alarm for Frontend 4xx Alarm ${SupportManualURL}"
+      AlarmDescription: !Sub "Trigger the warning alarm for Frontend 5XX Alarm ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-pagerduty-alert-topic
@@ -1030,7 +1030,7 @@ Resources:
           MetricStat:
             Metric:
               Namespace: AWS/ApiGateway
-              MetricName: 5xx
+              MetricName: 5XXError
               Dimensions:
                 - Name: ApiId
                   Value: !Ref ApiGwHttpEndpoint
@@ -1040,6 +1040,57 @@ Resources:
           Label: errorPercentage
           ReturnData: false
           Expression: (error/invocations) * 100
+
+  FE5XXErrorCriticalAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
+      AlarmDescription: >
+        Trigger the 5XX cricical alarm if errorThreshold exceeds 80% with 10 or more invocations
+        and a minimum of 2 errors in 5 out of the last 5 minutes
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-pagerduty-alert-topic
+        - !ImportValue platform-alarm-topic-critical-alert
+      AlarmActions:
+        - !ImportValue platform-alarm-pagerduty-alert-topic
+        - !ImportValue platform-alarm-topic-critical-alert
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 80
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: IF(invocations<10,0,errorPercentage)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: error
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5XXError
+              Dimensions:
+                - Name: ApiId
+                  Value: !GetAtt ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: errorPercentage
+          Label: errorPercentage
+          ReturnData: false
+          Expression: (error/invocations)*100
 
   FE4XXErrorAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/template.yaml
+++ b/template.yaml
@@ -1030,7 +1030,7 @@ Resources:
           MetricStat:
             Metric:
               Namespace: AWS/ApiGateway
-              MetricName: 5XXError
+              MetricName: 5xx
               Dimensions:
                 - Name: ApiId
                   Value: !Ref ApiGwHttpEndpoint
@@ -1081,7 +1081,7 @@ Resources:
           MetricStat:
             Metric:
               Namespace: AWS/ApiGateway
-              MetricName: 5XXError
+              MetricName: 5xx
               Dimensions:
                 - Name: ApiId
                   Value: !GetAtt ApiGwHttpEndpoint

--- a/template.yaml
+++ b/template.yaml
@@ -994,7 +994,7 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorAlarm"
-      AlarmDescription: !Sub "Trigger the warning alarm for Frontend 5XX Alarm ${SupportManualURL}"
+      AlarmDescription: !Sub "Trigger the warning alarm for Frontend 4xx Alarm ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-pagerduty-alert-topic
@@ -1040,57 +1040,6 @@ Resources:
           Label: errorPercentage
           ReturnData: false
           Expression: (error/invocations) * 100
-
-  FE5XXErrorCriticalAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
-      AlarmDescription: >
-        Trigger the 5XX cricical alarm if errorThreshold exceeds 80% with 10 or more invocations
-        and a minimum of 2 errors in 5 out of the last 5 minutes
-      ActionsEnabled: true
-      OKActions:
-        - !ImportValue platform-alarm-pagerduty-alert-topic
-        - !ImportValue platform-alarm-topic-critical-alert
-      AlarmActions:
-        - !ImportValue platform-alarm-pagerduty-alert-topic
-        - !ImportValue platform-alarm-topic-critical-alert
-      EvaluationPeriods: 5
-      DatapointsToAlarm: 2
-      Threshold: 80
-      ComparisonOperator: GreaterThanOrEqualToThreshold
-      TreatMissingData: notBreaching
-      Metrics:
-        - Id: errorThreshold
-          Label: errorThreshold
-          ReturnData: true
-          Expression: IF(invocations<10,0,errorPercentage)
-        - Id: invocations
-          ReturnData: false
-          MetricStat:
-            Metric:
-              Namespace: AWS/ApiGateway
-              MetricName: Count
-              Dimensions:
-                - Name: ApiId
-                  Value: !Ref ApiGwHttpEndpoint
-            Period: 60
-            Stat: Sum
-        - Id: error
-          ReturnData: false
-          MetricStat:
-            Metric:
-              Namespace: AWS/ApiGateway
-              MetricName: 5xx
-              Dimensions:
-                - Name: ApiId
-                  Value: !GetAtt ApiGwHttpEndpoint
-            Period: 60
-            Stat: Sum
-        - Id: errorPercentage
-          Label: errorPercentage
-          ReturnData: false
-          Expression: (error/invocations)*100
 
   FE4XXErrorAlarm:
     Type: AWS::CloudWatch::Alarm


### PR DESCRIPTION
### What changed

Added name to hmpo-logger.get() function to prevent use of sync API which blocks event loop

### Why did it change

Prevent blocking functions from impacting performance

### Issue tracking

- [KIWI-2012](https://govukverify.atlassian.net/browse/KIWI-2012)



[KIWI-2012]: https://govukverify.atlassian.net/browse/KIWI-2012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ