### PR TITLE
[KIWI-2216] Upgrade FE analytics from v 2.0.1 to 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "@aws-sdk/credential-providers": "^3.438.0",
     "@aws-sdk/lib-dynamodb": "3.363.0",
     "@govuk-one-login/di-ipv-cri-common-express": "10.3.0",
-    "@govuk-one-login/frontend-analytics": "2.0.1",
+    "@govuk-one-login/frontend-analytics": "3.1.0",
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",
     "@govuk-one-login/frontend-vital-signs": "0.1.3",

--- a/src/app.js
+++ b/src/app.js
@@ -158,7 +158,7 @@ setGTM({
   ga4FormChangeEnabled: APP.GTM.GA4_FORM_CHANGE_ENABLED,
   ga4NavigationEnabled: APP.GTM.GA4_NAVIGATION_ENABLED,
   ga4SelectContentEnabled: APP.GTM.GA4_SELECT_CONTENT_ENABLED,
-  analyticsDataSensitive: APP.GTM.ANALYTICS_DATA_SENSITIVE
+  analyticsDataSensitive: APP.GTM.ANALYTICS_DATA_SENSITIVE,
 });
 
 // Common express relies on 0/1 strings

--- a/src/app/cic/fields.test.js
+++ b/src/app/cic/fields.test.js
@@ -51,4 +51,3 @@ describe("Fields maxLength ", () => {
     });
   });
 });
-

--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -32,7 +32,8 @@ module.exports = {
       GA4_FORM_ERROR_ENABLED: process.env.GA4_FORM_ERROR_ENABLED || true,
       GA4_FORM_CHANGE_ENABLED: process.env.GA4_FORM_CHANGE_ENABLED || true,
       GA4_NAVIGATION_ENABLED: process.env.GA4_NAVIGATION_ENABLED || true,
-      GA4_SELECT_CONTENT_ENABLED: process.env.GA4_SELECT_CONTENT_ENABLED || true
+      GA4_SELECT_CONTENT_ENABLED:
+        process.env.GA4_SELECT_CONTENT_ENABLED || true,
     },
     LANGUAGE_TOGGLE_DISABLED: process.env.LANGUAGE_TOGGLE_DISABLED || "true",
   },

--- a/src/views/cic/enter-date-birth-hmrc-check.html
+++ b/src/views/cic/enter-date-birth-hmrc-check.html
@@ -32,7 +32,7 @@ html: formInstructions
 }) }}
 
 
-{{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-dob-continue-btn"}, text: translate("buttons.next")}) }}
+{{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-dob-continue-btn", "data-nav":true,"data-link":"/confirm-details-hmrc-check"}, text: translate("buttons.next")}) }}
 
 {% endcall %}
 

--- a/src/views/cic/enter-date-birth-no-photo-id.html
+++ b/src/views/cic/enter-date-birth-no-photo-id.html
@@ -32,7 +32,7 @@ html: formInstructions
 }) }}
 
 
-{{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-dob-continue-btn"}, text: translate("buttons.next")}) }}
+{{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-dob-continue-btn", "data-nav":true,"data-link":"/confirm-details-no-photo-id"}, text: translate("buttons.next")}) }}
 
 {% endcall %}
 

--- a/src/views/cic/enter-date-birth.html
+++ b/src/views/cic/enter-date-birth.html
@@ -32,7 +32,7 @@ html: formInstructions
 }) }}
 
 
-{{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-dob-continue-btn"}, text: translate("buttons.next")}) }}
+{{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-dob-continue-btn", "data-nav":true,"data-link":"/confirm-details"}, text: translate("buttons.next")}) }}
 
 {% endcall %}
 

--- a/src/views/cic/enter-name-hmrc-check.html
+++ b/src/views/cic/enter-name-hmrc-check.html
@@ -93,7 +93,7 @@
         }) }}
       </div>
 
-      {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-name-continue-btn"}, text: translate("buttons.next")}) }}
+      {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-name-continue-btn", "data-nav":true,"data-link":"/enter-date-birth-hmrc-check"}, text: translate("buttons.next")}) }}
 
       {% endcall %}
 

--- a/src/views/cic/enter-name-no-photo-id.html
+++ b/src/views/cic/enter-name-no-photo-id.html
@@ -94,7 +94,7 @@
       }) }}
     </div>
 
-    {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-name-continue-btn"}, text: translate("buttons.next")}) }}
+    {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-name-continue-btn", "data-nav":true,"data-link":"/enter-date-birth-no-photo-id"}, text: translate("buttons.next")}) }}
 
   {% endcall %}
 

--- a/src/views/cic/enter-name.html
+++ b/src/views/cic/enter-name.html
@@ -86,7 +86,7 @@
       }) }}
     </div>
 
-    {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-name-continue-btn"}, text: translate("buttons.next")}) }}
+    {{ hmpoSubmit(ctx, {classes: "govuk-!-margin-top-0", attributes: {"data-testid": "enter-name-continue-btn", "data-nav":true,"data-link":"/enter-date-birth"}, text: translate("buttons.next")}) }}
 
     {% endcall %}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1360,12 +1360,13 @@
     nocache "^3.0.4"
     redis "^4.7.0"
 
-"@govuk-one-login/frontend-analytics@2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-analytics/-/frontend-analytics-2.0.1.tgz#ff843241de1d1475407f719fb3f0f7180fc62dc1"
-  integrity sha512-8xAsQrRomVYxedFOQ8JDVdYx1JReJevSjU5EDZlcS/x3PhpCxm9DHjEqyOIvTo34zkFFoI4f2um6YkdD9IRQAg==
+"@govuk-one-login/frontend-analytics@3.1.0":
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/@govuk-one-login/frontend-analytics/-/frontend-analytics-3.1.0.tgz#7b8ad99ede1f5a0dbf81a62f375f26036d8b1e02"
+  integrity sha512-cHjuTWo7fLRwxjIcJCDG8cLheH/te77TZ03gDPvwvMRxI3xmCZ0HDQ2fVAHn6PMzOzPxODn5EUQIUQKxWhJskw==
   dependencies:
     copy-webpack-plugin "^12.0.2"
+    loglevel "^1.9.1"
 
 "@govuk-one-login/frontend-language-toggle@^1.1.0":
   version "1.1.0"
@@ -5909,6 +5910,11 @@ log-symbols@4.1.0:
   dependencies:
     chalk "^4.1.0"
     is-unicode-supported "^0.1.0"
+
+loglevel@^1.9.1:
+  version "1.9.2"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
+  integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
 
 lolex@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
### What changed

Upgraded frontend-analytics package version and added missing data attributes used for GA4 navigation tracking

### Why did it change

To ensure service is up to date and capturing analytics data correctly

### Issue tracking

- [KIWI-2216](https://govukverify.atlassian.net/browse/KIWI-2216)


### Evidence

<img width="1920" alt="Screenshot 2025-03-14 at 14 37 10" src="https://github.com/user-attachments/assets/31f20c69-3365-4bc9-abfb-c0d5b67849e5" />
<img width="903" alt="Screenshot 2025-03-14 at 14 37 30" src="https://github.com/user-attachments/assets/d6889c12-9a18-4d0d-9748-64ce45cc0e4d" />
<img width="626" alt="Screenshot 2025-03-14 at 14 40 22" src="https://github.com/user-attachments/assets/d5964af1-2ce1-4d2d-b07a-1690d94b261b" />


https://github.com/user-attachments/assets/e5a8e03e-8024-4579-b0ca-2aee5f4d9314



[KIWI-2216]: https://govukverify.atlassian.net/browse/KIWI-2216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ