### PR TITLE
KIWI-2016 - Adding Sigterm graceful close

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -72,7 +72,7 @@ const helmetConfig = require("./lib/helmet.js");
 
 const { app, router } = setup({
   config: { APP_ROOT: __dirname },
-  port: PORT,
+  port: false,
   logs: loggerConfig,
   session: sessionConfig,
   helmet: helmetConfig,
@@ -159,6 +159,60 @@ setGTM({
   ga4NavigationEnabled: APP.GTM.GA4_NAVIGATION_ENABLED,
   ga4SelectContentEnabled: APP.GTM.GA4_SELECT_CONTENT_ENABLED,
   analyticsDataSensitive: APP.GTM.ANALYTICS_DATA_SENSITIVE
+});
+
+/* Server configuration */
+const server = app.listen(PORT);
+
+// AWS recommends the keep-alive duration of the target is longer than the idle timeout value of the load balancer (default 60s)
+// to prevent possible 502 errors where the target connection has already been closed
+// https://docs.aws.amazon.com/elast
+server.keepAliveTimeout = 65000;
+
+// Handles graceful shutdown of the NODE service, so that if the container is killed by a SIGTERM, it finishes processing existing connections before the server shuts down.
+let serverAlreadyExiting = false;
+let exitCode = 0;
+const MAX_EXIT_WAIT = 30000;
+process.on("SIGTERM", () => {
+  if (serverAlreadyExiting) {
+    // eslint-disable-next-line no-console
+    console.log("SIGTERM signal received: Server close already called");
+    return;
+  }
+  serverAlreadyExiting = true;
+
+  // eslint-disable-next-line no-console
+  console.log("SIGTERM signal received: closing HTTP server");
+
+  // Stop accepting new connections
+  server.close((err) => {
+    if (err) {
+      // eslint-disable-next-line no-console
+      console.log(
+        `Error while calling server.close() occurred: ${err.message}`
+      );
+
+      exitCode = 1;
+    } else {
+      // eslint-disable-next-line no-console
+      console.log("HTTP server closed");
+    }
+  });
+
+  // There maybe active timers in the event loop preventing a clean exit.
+  // Give remaining active connections some time to compelte
+  // Then exit, this also closes any connection with keep-alive set
+  setTimeout(() => {
+    // eslint-disable-next-line no-console
+    console.log(`Waiting ${MAX_EXIT_WAIT}ms for before exiting fully`);
+
+    // Close any active connections that have not closed (KeepAlives/Idle etc)
+    server.closeAllConnections();
+
+    // eslint-disable-next-line no-console
+    console.log(`Calling process exit ${exitCode}`);
+    process.exit(exitCode);
+  }, MAX_EXIT_WAIT);
 });
 
 // Common express relies on 0/1 strings


### PR DESCRIPTION
### What changed
Add SIGTERM shutdown, and adjust keepalivetimeout duration to longer than loadbalancer timeout

### Why did it change
To implement gracefull shutdown and avoid mismatch between loadbalancer timeout and keepalive.
