### PR TITLE
[KIWI-2015] - | CM | Ensure that there is a 5XX Alarm if more than 80% of your traffic is returning 5XX in 2 of 5 datapoints.

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -1078,7 +1078,7 @@ Resources:
     Condition: IsNotDevelopment
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorAlarm"
-      AlarmDescription: !Sub "Trigger the warning alarm for Frontend 4xx Alarm ${SupportManualURL}"
+      AlarmDescription: !Sub "Trigger the warning alarm for Frontend 5xx Alarm ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
         - !ImportValue platform-alarm-pagerduty-alert-topic
@@ -1124,6 +1124,57 @@ Resources:
           Label: errorPercentage
           ReturnData: false
           Expression: (error/invocations) * 100
+  
+  FE5XXErrorCriticalAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
+      AlarmDescription: >
+        Trigger the 5XX cricical alarm if errorThreshold exceeds 80% with 10 or more invocations
+        and a minimum of 2 errors in 5 out of the last 5 minutes
+      ActionsEnabled: true
+      OKActions:
+        - !ImportValue platform-alarm-pagerduty-alert-topic
+        - !ImportValue platform-alarm-topic-critical-alert
+      AlarmActions:
+        - !ImportValue platform-alarm-pagerduty-alert-topic
+        - !ImportValue platform-alarm-topic-critical-alert
+      EvaluationPeriods: 5
+      DatapointsToAlarm: 2
+      Threshold: 80
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      TreatMissingData: notBreaching
+      Metrics:
+        - Id: errorThreshold
+          Label: errorThreshold
+          ReturnData: true
+          Expression: IF(invocations<10,0,errorPercentage)
+        - Id: invocations
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: Count
+              Dimensions:
+                - Name: ApiId
+                  Value: !Ref ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: error
+          ReturnData: false
+          MetricStat:
+            Metric:
+              Namespace: AWS/ApiGateway
+              MetricName: 5xx
+              Dimensions:
+                - Name: ApiId
+                  Value: !GetAtt ApiGwHttpEndpoint
+            Period: 60
+            Stat: Sum
+        - Id: errorPercentage
+          Label: errorPercentage
+          ReturnData: false
+          Expression: (error/invocations)*100
 
   FE4XXErrorAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/template.yaml
+++ b/template.yaml
@@ -1125,7 +1125,6 @@ Resources:
   
   FE5XXErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: IsNotDevelopment
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
       AlarmDescription: >
@@ -1133,8 +1132,10 @@ Resources:
         and a minimum of 2 errors in 5 out of the last 5 minutes
       ActionsEnabled: true
       OKActions:
+        - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-topic-critical-alert
       AlarmActions:
+        - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-topic-critical-alert
       EvaluationPeriods: 5
       DatapointsToAlarm: 2

--- a/template.yaml
+++ b/template.yaml
@@ -1084,6 +1084,7 @@ Resources:
         - !ImportValue platform-alarm-topic-slack-warning-alert
       AlarmActions:
         - !ImportValue platform-alarm-topic-slack-warning-alert
+      # Invocation count to be reviewed
       InsufficientDataActions: []
       Dimensions: []
       EvaluationPeriods: 5

--- a/template.yaml
+++ b/template.yaml
@@ -1125,6 +1125,7 @@ Resources:
   
   FE5XXErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: IsNotDevelopment
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
       AlarmDescription: >

--- a/template.yaml
+++ b/template.yaml
@@ -1125,7 +1125,7 @@ Resources:
   
   FE5XXErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: IsNotDevelopment
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
       AlarmDescription: >

--- a/template.yaml
+++ b/template.yaml
@@ -1081,11 +1081,9 @@ Resources:
       AlarmDescription: !Sub "Trigger the warning alarm for Frontend 5xx Alarm ${SupportManualURL}"
       ActionsEnabled: true
       OKActions:
-        - !ImportValue platform-alarm-pagerduty-alert-topic
-        - !ImportValue platform-alarm-topic-critical-alert
+        - !ImportValue platform-alarm-topic-slack-warning-alert
       AlarmActions:
-        - !ImportValue platform-alarm-pagerduty-alert-topic
-        - !ImportValue platform-alarm-topic-critical-alert
+        - !ImportValue platform-alarm-topic-slack-warning-alert
       InsufficientDataActions: []
       Dimensions: []
       EvaluationPeriods: 5
@@ -1127,6 +1125,7 @@ Resources:
   
   FE5XXErrorCriticalAlarm:
     Type: AWS::CloudWatch::Alarm
+    Condition: "DeployAlarms"
     Properties:
       AlarmName: !Sub "${AWS::StackName}-FE5XXErrorCriticalAlarm"
       AlarmDescription: >
@@ -1134,10 +1133,8 @@ Resources:
         and a minimum of 2 errors in 5 out of the last 5 minutes
       ActionsEnabled: true
       OKActions:
-        - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-topic-critical-alert
       AlarmActions:
-        - !ImportValue platform-alarm-pagerduty-alert-topic
         - !ImportValue platform-alarm-topic-critical-alert
       EvaluationPeriods: 5
       DatapointsToAlarm: 2
@@ -1168,7 +1165,7 @@ Resources:
               MetricName: 5xx
               Dimensions:
                 - Name: ApiId
-                  Value: !GetAtt ApiGwHttpEndpoint
+                  Value: !Ref ApiGwHttpEndpoint
             Period: 60
             Stat: Sum
         - Id: errorPercentage


### PR DESCRIPTION
### What changed

Implement 5XX critical alarm with Slack notifications to send alerts when there is a high volume of 5XX errors

### Why did it change

To alert team Kiwi so that they can respond to the errors

### Issue tracking

- [KIWI-2015](https://govukverify.atlassian.net/browse/KIWI-2015)

![Screenshot 2025-03-19 at 16 00 41 (2)](https://github.com/user-attachments/assets/d3297f76-e077-488f-b0be-9c7906e2d501)

<img width="1512" alt="Screenshot 2025-03-19 at 16 00 41" src="https://github.com/user-attachments/assets/7b74b9bc-9663-44c8-ae06-edb40388727e" />


<!-- Add any other consideration if needed -->


[KIWI-2015]: https://govukverify.atlassian.net/browse/KIWI-2015?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
