### PR TITLE
[KIWI-2020] - | CM | Set minimum container count for initial scaling load

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -41,14 +41,6 @@ Parameters:
     Description: "The ARN of the permissions boundary to apply when creating IAM roles"
     Type: String
     Default: "none"
-  MaxContainerCount:
-    Description: Maximum number of FE node/express container tasks to allow autoscaling to reach
-    Type: Number
-    Default: 12
-  MinContainerCount:
-    Description: Minimum number of FE node/express container tasks to allow autoscaling to reach
-    Type: Number
-    Default: 3
   SupportManualURL:
     Description: "Link to the CIC support manual"
     Type: String
@@ -475,7 +467,7 @@ Resources:
           DeploymentCircuitBreaker:
             Enable: TRUE
             Rollback: TRUE
-      DesiredCount: !Ref MinContainerCount
+      DesiredCount: !FindInMap [EnvironmentVariables, !Ref Environment, minECSCount]
       EnableECSManagedTags: false
       HealthCheckGracePeriodSeconds: 60
       LaunchType: FARGATE

--- a/template.yaml
+++ b/template.yaml
@@ -124,32 +124,6 @@ Mappings:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
     production:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-  EnvironmentConfiguration:
-    dev:
-      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      minECSCount: 1
-      maxECSCount: 4
-      logLevel: "info"
-    build:
-      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      minECSCount: 6
-      maxECSCount: 60
-      logLevel: "info"
-    staging:
-      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      minECSCount: 2
-      maxECSCount: 4
-      logLevel: "warn"
-    integration:
-      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
-      minECSCount: 2
-      maxECSCount: 4
-      logLevel: "warn"
-    production:
-      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
-      minECSCount: 6
-      maxECSCount: 60
-      logLevel: "warn"
 # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
     eu-west-2:
@@ -986,9 +960,9 @@ Resources:
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
       MinCapacity:
-        !FindInMap [EnvironmentConfiguration, !Ref Environment, minECSCount]
+        !FindInMap [EnvironmentVariables, !Ref Environment, minECSCount]
       MaxCapacity:
-        !FindInMap [EnvironmentConfiguration, !Ref Environment, maxECSCount]
+        !FindInMap [EnvironmentVariables, !Ref Environment, maxECSCount]
       ResourceId: !Join
         - '/'
         - - "service"

--- a/template.yaml
+++ b/template.yaml
@@ -124,7 +124,32 @@ Mappings:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
     production:
       CSLSEGRESS: arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython
-
+  EnvironmentConfiguration:
+    dev:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      minECSCount: 1
+      maxECSCount: 4
+      logLevel: "info"
+    build:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      minECSCount: 6
+      maxECSCount: 60
+      logLevel: "info"
+    staging:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      minECSCount: 2
+      maxECSCount: 4
+      logLevel: "warn"
+    integration:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
+      minECSCount: 2
+      maxECSCount: 4
+      logLevel: "warn"
+    production:
+      dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
+      minECSCount: 6
+      maxECSCount: 60
+      logLevel: "warn"
 # see https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html
   ElasticLoadBalancerAccountIds:
     eu-west-2:
@@ -149,6 +174,8 @@ Mappings:
       BACKENDSESSIONTABLE: "session-cic-cri-ddb"
       LOGLEVEL: "debug"
       LANGUAGETOGGLEDISABLED: false
+      minECSCount: 1
+      maxECSCount: 4
     build:
       EXTERNALWEBSITEHOST: "https://review-c.build.account.gov.uk"
       APIBASEURL: "https://api.review-c.build.account.gov.uk"
@@ -165,6 +192,8 @@ Mappings:
       BACKENDSESSIONTABLE: "session-cic-cri-ddb"
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
+      minECSCount: 6
+      maxECSCount: 60
     staging:
       EXTERNALWEBSITEHOST: "https://review-c.staging.account.gov.uk"
       APIBASEURL: "https://api.review-c.staging.account.gov.uk"
@@ -181,6 +210,8 @@ Mappings:
       BACKENDSESSIONTABLE: ""
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
+      minECSCount: 2
+      maxECSCount: 4
     integration:
       EXTERNALWEBSITEHOST: "https://review-c.integration.account.gov.uk"
       APIBASEURL: "https://api.review-c.integration.account.gov.uk"
@@ -197,6 +228,8 @@ Mappings:
       BACKENDSESSIONTABLE: ""
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
+      minECSCount: 2
+      maxECSCount: 4
     production:
       EXTERNALWEBSITEHOST: "https://review-c.account.gov.uk"
       APIBASEURL: "https://api.review-c.account.gov.uk"
@@ -213,6 +246,8 @@ Mappings:
       BACKENDSESSIONTABLE: ""
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
+      minECSCount: 6
+      maxECSCount: 60
 
 Resources:
   # Security Groups for the ECS service and load balancer
@@ -950,8 +985,10 @@ Resources:
     Condition: EnableScaling
     Type: AWS::ApplicationAutoScaling::ScalableTarget
     Properties:
-      MaxCapacity: !Ref MaxContainerCount
-      MinCapacity: !Ref MinContainerCount
+      MinCapacity:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, minECSCount]
+      MaxCapacity:
+        !FindInMap [EnvironmentConfiguration, !Ref Environment, maxECSCount]
       ResourceId: !Join
         - '/'
         - - "service"


### PR DESCRIPTION
### What changed

Set minimum and maximum containers for each environment

### Why did it change

Allow the service to scale appropriately. Capacity is higher in build and production where we do perf tests

- [KIWI-2020](https://govukverify.atlassian.net/browse/KIWI-2020)
