### PR TITLE
KIWI-2010 - Implementing oveload protection

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
   "dependencies": {
     "@aws-sdk/credential-providers": "^3.438.0",
     "@aws-sdk/lib-dynamodb": "3.363.0",
-    "@govuk-one-login/di-ipv-cri-common-express": "10.3.0",
+    "@govuk-one-login/di-ipv-cri-common-express": "10.6.0",
     "@govuk-one-login/frontend-analytics": "3.1.0",
     "@govuk-one-login/frontend-language-toggle": "^1.1.0",
     "@govuk-one-login/frontend-passthrough-headers": "1.0.0",

--- a/src/app.js
+++ b/src/app.js
@@ -18,6 +18,7 @@ const { setAPIConfig, setOAuthPaths } = require("./lib/settings");
 
 const { setGTM, setLanguageToggle } = commonExpress.lib.settings;
 const { getGTM, getLanguageToggle } = commonExpress.lib.locals;
+const overloadProtectionConfigService = require("./lib/overload-protection-config.js");
 
 const addLanguageParam = require("@govuk-one-login/frontend-language-toggle/build/cjs/language-param-setter.cjs");
 
@@ -69,6 +70,8 @@ const sessionConfig = {
   ...(SESSION_TABLE_NAME && { sessionStore: dynamoDBSessionStore }),
 };
 
+const overloadProtectionConfig = overloadProtectionConfigService.init();
+
 const helmetConfig = require("./lib/helmet.js");
 
 const { app, router } = setup({
@@ -119,6 +122,7 @@ const { app, router } = setup({
     });
     app.use(setHeaders);
   },
+  overloadProtection: overloadProtectionConfig,
   dev: true,
 });
 
@@ -187,7 +191,7 @@ process.on("SIGTERM", () => {
   server.close((err) => {
     if (err) {
       console.log(
-        `Error while calling server.close() occurred: ${err.message}`
+        `Error while calling server.close() occurred: ${err.message}`,
       );
 
       exitCode = 1;

--- a/src/lib/overload-protection-config.js
+++ b/src/lib/overload-protection-config.js
@@ -1,0 +1,17 @@
+const init = () => {
+  const protectConfig = {
+    production: "production", // if production is false, detailed error messages are exposed to the client
+    clientRetrySecs: 1, // Retry-After header, in seconds (0 to disable) [default 1]
+    sampleInterval: 5, // sample rate, milliseconds [default 5]
+    maxEventLoopDelay: 900, // maximum detected delay between event loop ticks [default 42]
+    maxHeapUsedBytes: 0, // maximum heap used threshold (0 to disable) [default 0]
+    maxRssBytes: 0, // maximum rss size threshold (0 to disable) [default 0]
+    errorPropagationMode: false, // dictate behavior: take over the response
+    // or propagate an error to the framework [default false]
+    logging: false, // set to string for log level or function to pass data
+  };
+
+  return protectConfig;
+};
+
+module.exports = { init };


### PR DESCRIPTION
### What changed
Implemented overload protection to return 503s from the FE when event loop delay exceeds threshold indicating node app is overloaded