### PR TITLE
Device intelligence unhappy path

### DIFF
--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -38,6 +38,10 @@ jobs:
           CUSTOM_FE_URL: http://localhost:5020
           LANGUAGE_TOGGLE_DISABLED: false
       - run: npm run test:browser:no_di
+        env:
+          IPV_STUB_URL: ${{ secrets.IPV_STUB_URL }}
+          CUSTOM_FE_URL: http://localhost:5020
+          LANGUAGE_TOGGLE_DISABLED: false
       - name: Archive browser tests results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -37,6 +37,7 @@ jobs:
           IPV_STUB_URL: ${{ secrets.IPV_STUB_URL }}
           CUSTOM_FE_URL: http://localhost:5020
           LANGUAGE_TOGGLE_DISABLED: false
+      - run: npm run test:browser:no_di
       - name: Archive browser tests results
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -37,7 +37,7 @@ jobs:
           IPV_STUB_URL: ${{ secrets.IPV_STUB_URL }}
           CUSTOM_FE_URL: http://localhost:5020
           LANGUAGE_TOGGLE_DISABLED: false
-      - run: npm run test:browser:no_di
+      - run: npm run test:browser:no_di:ci
         env:
           IPV_STUB_URL: ${{ secrets.IPV_STUB_URL }}
           CUSTOM_FE_URL: http://localhost:5020

--- a/package.json
+++ b/package.json
@@ -27,7 +27,12 @@
     "test": "mocha",
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary yarn test",
     "test:watch": "mocha --watch",
+<<<<<<< Updated upstream
     "test:browser": "wait-on tcp:127.0.0.1:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @browser",
+=======
+    "test:browser": "wait-on tcp:127.0.0.1:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @browsers",
+    "test:browser:no_di": "DEVICE_INTELLIGENCE_ENABLED=false wait-on tcp:127.0.0.1:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @device_intelligence_unhappy",
+>>>>>>> Stashed changes
     "test:browser:only": "wait-on tcp:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js --tags @only",
     "test:browser:ci": "npm-run-all -p -r start:ci test:browser && npm run test:browser:report",
     "test:browser:ci:only": "npm-run-all -p -r start:ci test:browser:only",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "test:browser:no_di": "DEVICE_INTELLIGENCE_ENABLED=false wait-on tcp:127.0.0.1:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @device_intelligence_unhappy",
     "test:browser:only": "wait-on tcp:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js --tags @only",
     "test:browser:ci": "npm-run-all -p -r start:ci test:browser && npm run test:browser:report",
-    "test:browser:no_di:ci": "npm-run-all -p -r start:ci test:browser:no_di && npm run test:browser:report",
+    "test:browser:no_di:ci": "npm-run-all -p -r start:ci test:browser:no_di",
     "test:browser:ci:only": "npm-run-all -p -r start:ci test:browser:only",
     "check-translation": "node node_modules/@govuk-one-login/di-ipv-cri-common-express/scripts/checkTranslations.js '../../../../src/locales'",
     "test:browser:report": "node ./test/utils/multiReportGenerator.js",

--- a/package.json
+++ b/package.json
@@ -27,12 +27,8 @@
     "test": "mocha",
     "test:coverage": "nyc --reporter=lcov --reporter=text-summary yarn test",
     "test:watch": "mocha --watch",
-<<<<<<< Updated upstream
     "test:browser": "wait-on tcp:127.0.0.1:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @browser",
-=======
-    "test:browser": "wait-on tcp:127.0.0.1:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @browsers",
     "test:browser:no_di": "DEVICE_INTELLIGENCE_ENABLED=false wait-on tcp:127.0.0.1:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @device_intelligence_unhappy",
->>>>>>> Stashed changes
     "test:browser:only": "wait-on tcp:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js --tags @only",
     "test:browser:ci": "npm-run-all -p -r start:ci test:browser && npm run test:browser:report",
     "test:browser:ci:only": "npm-run-all -p -r start:ci test:browser:only",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:browser:no_di": "DEVICE_INTELLIGENCE_ENABLED=false wait-on tcp:127.0.0.1:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js -f json:./test/reports/cucumber_report.json --tags @device_intelligence_unhappy",
     "test:browser:only": "wait-on tcp:5020 && cucumber-js test/browser/features/**/*.feature --require test/browser/support/env.js  --require test/browser/support/setup.js --require test/browser/step_definitions/**/*.js --tags @only",
     "test:browser:ci": "npm-run-all -p -r start:ci test:browser && npm run test:browser:report",
+    "test:browser:no_di:ci": "npm-run-all -p -r start:ci test:browser:no_di && npm run test:browser:report",
     "test:browser:ci:only": "npm-run-all -p -r start:ci test:browser:only",
     "check-translation": "node node_modules/@govuk-one-login/di-ipv-cri-common-express/scripts/checkTranslations.js '../../../../src/locales'",
     "test:browser:report": "node ./test/utils/multiReportGenerator.js",

--- a/test/browser/features/BrowserBasedTests/UnHappyPath/Cookies/CICCookies.feature
+++ b/test/browser/features/BrowserBasedTests/UnHappyPath/Cookies/CICCookies.feature
@@ -1,0 +1,9 @@
+@device_intelligence_unhappy
+
+Feature: Claimed Identity Credential Issuer Device Intelligence Cookie - Negative Path
+
+    Scenario: Claimed Identity Credential Issuer - Device Intelligence Cookie
+        Given Authenticatable Anita is using the system
+        When they have provided their details
+        Then they should be redirected to the F2F nameEntry
+        And the "di-device-intelligence" cookie has not been set

--- a/test/browser/pages/nameEntryPage.js
+++ b/test/browser/pages/nameEntryPage.js
@@ -12,6 +12,7 @@ module.exports = class PlaywrightDevPage {
 
   async isCurrentPage() {
     const { pathname } = new URL(this.page.url());
+    console.log("Expected Pathname: " + this.path + ". Actual Pathname: " + pathname);
     return pathname === this.path;
   }
 

--- a/test/browser/step_definitions/details.js
+++ b/test/browser/step_definitions/details.js
@@ -20,7 +20,7 @@ When(
   {
     timeout: 10 * 1000,
   },
-  async function () {},
+  async function () { },
 );
 
 Then("they should be redirected to the F2F nameEntry", async function () {
@@ -50,7 +50,7 @@ Then("they should be redirected to the BAV nameEntry", async function () {
   );
   expect(await nameEntryPage.checkSubTitleForBAV()).to.contain(
     "Check your banking app, online bank account or bank statement for the full registered name." && // eslint-disable-line
-      "The name on your bank card might only use your initials.",
+    "The name on your bank card might only use your initials.",
   );
 });
 
@@ -90,8 +90,14 @@ When(
   },
 );
 
-Then("the {string} cookie has been set", async function(cookieName) {
+Then("the {string} cookie has been set", async function (cookieName) {
   const cookies = await this.page.context().cookies();
   const expectedCookie = cookies.find(cookie => cookie.name === cookieName);
   expect(expectedCookie).to.exist;
+});
+
+Then("the {string} cookie has not been set", async function (cookieName) {
+  const cookies = await this.page.context().cookies();
+  const expectedCookie = cookies.find(cookie => cookie.name === cookieName);
+  expect(expectedCookie).to.not.exist;
 });


### PR DESCRIPTION
## Proposed changes

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

### What changed

Add Unhappy Path test for Device Intelligence cookies

### Why did it change

Ensure feature flag is working as expected and no device_intelligence cookies are present when flag is set to false

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-XXXX](https://govukverify.atlassian.net/browse/KIWI-XXXX)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the README
- [ ] Added screenshots to show the implementation is working
- [ ] Ran cfn-lint on any SAM templates

### Other considerations

<!-- Add any other consideration if needed -->
