### PR TITLE
Pipeline fix - Disabled DI browser tests from pipeline

### DIFF
--- a/test/browser/features/BrowserBasedTests/HappyPath/CICCookies.feature
+++ b/test/browser/features/BrowserBasedTests/HappyPath/CICCookies.feature
@@ -1,4 +1,4 @@
-@browser
+@success @e2e
 
 Feature: Claimed Identity Credential Issuer Device Intelligence Cookie
 


### PR DESCRIPTION
### What changed

Disabled DI browser tests from pipeline

### Why did it change

This is in line with the choice made with other Kiwi CRI's that browser tests that attempt to validate cookie presence should not run in the pipeline as they currently fail for unknown reasons - tech debt will be raised to investigate.