### PR TITLE
[KIWI-2318] - DI | Set Cookie domain for all environments

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -38,7 +38,7 @@ module.exports = {
     },
     LANGUAGE_TOGGLE_DISABLED: process.env.LANGUAGE_TOGGLE_DISABLED || "true",
     DEVICE_INTELLIGENCE_ENABLED: process.env.DEVICE_INTELLIGENCE_ENABLED || "true",
-    DEVICE_INTELLIGENCE_DOMAIN: process.env.FRONTEND_DOMAIN || "localhost",
+    DEVICE_INTELLIGENCE_DOMAIN: process.env.DEVICE_INTELLIGENCE_DOMAIN || "localhost",
   },
   PORT: process.env.PORT || 5020,
   SESSION_SECRET: process.env.SESSION_SECRET,

--- a/template.yaml
+++ b/template.yaml
@@ -135,6 +135,7 @@ Mappings:
       GTMIDGA4: "GTM-KD86CMZ"
       GA4ENABLED: "true"
       ANALYTICSDOMAIN: "dev.account.gov.uk"
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       TESTHARNESSURL: "https://cic-test-harness-testharness.review-c.dev.account.gov.uk"
       BACKENDURL: "https://api-cic-cri-api.review-c.dev.account.gov.uk"
       BACKENDSESSIONTABLE: "session-cic-cri-ddb"
@@ -154,6 +155,7 @@ Mappings:
       GTMIDGA4: "GTM-KD86CMZ"
       GA4ENABLED: "true"
       ANALYTICSDOMAIN: "build.account.gov.uk"
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       TESTHARNESSURL: "https://testharness.review-c.build.account.gov.uk"
       BACKENDURL: "https://api.review-c.build.account.gov.uk"
       BACKENDSESSIONTABLE: "session-cic-cri-ddb"
@@ -173,6 +175,7 @@ Mappings:
       GTMIDGA4: "GTM-KD86CMZ"
       GA4ENABLED: "true"
       ANALYTICSDOMAIN: "staging.account.gov.uk"
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       TESTHARNESSURL: ""
       BACKENDURL: ""
       BACKENDSESSIONTABLE: ""
@@ -192,6 +195,7 @@ Mappings:
       GTMIDGA4: "GTM-KD86CMZ"
       GA4ENABLED: "false"
       ANALYTICSDOMAIN: "integration.account.gov.uk"
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       TESTHARNESSURL: ""
       BACKENDURL: ""
       BACKENDSESSIONTABLE: ""
@@ -211,6 +215,7 @@ Mappings:
       GTMIDGA4: "GTM-K4PBJH3"
       GA4ENABLED: "false"
       ANALYTICSDOMAIN: "account.gov.uk"
+      DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       TESTHARNESSURL: ""
       BACKENDURL: ""
       BACKENDSESSIONTABLE: ""
@@ -665,6 +670,8 @@ Resources:
                   "account.gov.uk",
                   !Sub "${Environment}.account.gov.uk"
                 ]
+            - Name: DEVICE_INTELLIGENCE_DOMAIN
+              Value: !FindInMap [ EnvironmentVariables, !Ref Environment, DEVICEINTELLIGENCEDOMAIN ]
             - Name: LOG_LEVEL
               Value: !FindInMap [EnvironmentVariables, !Ref Environment, LOGLEVEL ]
             - Name: LANGUAGE_TOGGLE_DISABLED


### PR DESCRIPTION
### What changed

Set device intelligence cookie domain to account.gov.uk across all envs

### Why did it change

To address issue with header size stemming from environment specific domain names

### Issue tracking

- [KIWI-2318](https://govukverify.atlassian.net/browse/KIWI-2318)

![Screenshot 2025-05-22 at 11 52 47](https://github.com/user-attachments/assets/c49bb40a-08e7-432d-9887-5a66717e3708)


