### PR TITLE
Small fix for DI cookie browser test

### DIFF
--- a/test/browser/step_definitions/details.js
+++ b/test/browser/step_definitions/details.js
@@ -91,6 +91,8 @@ When(
 );
 
 Then("the {string} cookie has been set", async function (cookieName) {
+  // Wait for the page to fully load
+  await this.page.waitForLoadState("networkidle", { timeout: 5000 });
   const cookies = await this.page.context().cookies();
   const expectedCookie = cookies.find(cookie => cookie.name === cookieName);
   expect(expectedCookie).to.exist;


### PR DESCRIPTION
### What changed

Small fix for DI cookie browser test by adding a wait time to the test

### Why did it change

The assumption is that this test was failing in the pipeline due to the test running before the page had finished loading, therefore the expected cookie was not present.