### PR TITLE
[KIWI-2251] - | FE | Enable feature flag for Device Intelligence in INT and PROD

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -181,7 +181,7 @@ Mappings:
       BACKENDSESSIONTABLE: ""
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
-      DEVICEINTELLIGENCEENABLED: false
+      DEVICEINTELLIGENCEENABLED: true
       minECSCount: 2
       maxECSCount: 4
     integration:
@@ -201,7 +201,7 @@ Mappings:
       BACKENDSESSIONTABLE: ""
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
-      DEVICEINTELLIGENCEENABLED: false
+      DEVICEINTELLIGENCEENABLED: true
       minECSCount: 2
       maxECSCount: 4
     production:
@@ -221,7 +221,7 @@ Mappings:
       BACKENDSESSIONTABLE: ""
       LOGLEVEL: "warn"
       LANGUAGETOGGLEDISABLED: false
-      DEVICEINTELLIGENCEENABLED: false
+      DEVICEINTELLIGENCEENABLED: true
       minECSCount: 6
       maxECSCount: 60
 


### PR DESCRIPTION
### What changed

Turned on Device Intelligence in staging, integration and production

### Why did it change

To enable the program to collect collection and analysis of data from end user devices and satisfy HMRC Day2 Must Have requirements

### Issue tracking

- [KIWI-2251](https://govukverify.atlassian.net/browse/KIWI-2251)

[KIWI-2251]: https://govukverify.atlassian.net/browse/KIWI-2251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ