### PR TITLE
Fix Post merge checks GitHub action

### DIFF
--- a/.github/workflows/post-merge-checks.yml
+++ b/.github/workflows/post-merge-checks.yml
@@ -92,7 +92,7 @@ jobs:
         if: ${{ github.actor != 'dependabot[bot]' }}
         uses: peaceiris/actions-gh-pages@v4.0.0
         with:
-          github_token: ${{ secrets.SH_CIC_ACCESS_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_branch: gh-pages
-          publish_dir: gh-pages/test-reports/post-merge-checks/QA
+          publish_dir: results-history
           keep_files: true


### PR DESCRIPTION
## Proposed changes

### What changed

- Added `workflow_name` input  to Cucumber HTML Report action
- Updated the GitHub token to Publish Github Pages action

### Why did it change

To fix post merge checks GitHub action failures 

