### PR TITLE
[KIWI-2423] - Dependabot | Sprint 6 | Update yaml file 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,10 @@ updates:
     ignore:
       - dependency-name: "node"
         versions: ["14.x","15.x","16.x","17.x","18.x","20.x","24.x"]
+    groups:
+      awssdk:
+        patterns:
+            - "@aws-sdk/*"
     commit-message:
       prefix: BAU
   - package-ecosystem: docker

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     - dependabot
     ignore:
       - dependency-name: "node"
-        versions: ["14.x","15.x","16.x","17.x","18.x","20.x"]
+        versions: ["14.x","15.x","16.x","17.x","18.x","20.x","24.x"]
     commit-message:
       prefix: BAU
   - package-ecosystem: docker
@@ -21,6 +21,9 @@ updates:
     target-branch: main
     labels:
     - dependabot
+    ignore:
+      - dependency-name: "node"
+        versions: ["24.x"]
     commit-message:
       prefix: BAU
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
## Proposed changes

### What changed

Updated dependabot yaml to group aws-sdk, and ignored arm64v8/node 24

### Why did it change

To group aws-sdk related PRs together, and ignore node 24

### Issue tracking

- [KIWI-2423](https://govukverify.atlassian.net/browse/KIWI-2423)
