### PR TITLE
KIWI-2651 enabling pino logger in higher envs

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -166,7 +166,7 @@ Mappings:
       ANALYTICSDOMAIN: "staging.account.gov.uk"
       DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       LOGLEVEL: "warn"
-      USEPINOLOGGER: false
+      USEPINOLOGGER: true
       minECSCount: 2
       maxECSCount: 4
     integration:
@@ -180,7 +180,7 @@ Mappings:
       ANALYTICSDOMAIN: "integration.account.gov.uk"
       DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       LOGLEVEL: "warn"
-      USEPINOLOGGER: false
+      USEPINOLOGGER: true
       minECSCount: 2
       maxECSCount: 4
     production:
@@ -194,7 +194,7 @@ Mappings:
       ANALYTICSDOMAIN: "account.gov.uk"
       DEVICEINTELLIGENCEDOMAIN: "account.gov.uk"
       LOGLEVEL: "warn"
-      USEPINOLOGGER: false
+      USEPINOLOGGER: true
       minECSCount: 6
       maxECSCount: 60
 


### PR DESCRIPTION
## Proposed changes

### What changed

After the following changes which are enabled in dev and staging were merged - we have enabled them in our higher envs for a phased roll out
- Migrated app logging away from direct `hmpo-logger` usage.
- Added a local logger wrapper around the common-express logger so the app can use Pino-style structured logging while still falling back safely when Pino is disabled.
- Added `USE_PINO_LOGGER` to the ECS task environment.
- Uses `USE_PINO_LOGGER` as the rollout switch, with Pino enabled only in lower environments initially:
  - `dev`: `"true"`
  - `build`: `"true"`
  - `staging`: `"false"`
  - `integration`: `"false"`
  - `production`: `"false"`
- Removed hmpo dep

### Why did it change

This enables the HMPO logger to Pino migration using the same staged rollout approach as BAV/CIC. Pino has already been enabled first in dev and build, currently our higher environments are using the HMPO fallback but this change will enable our pino changes to be turned on across all envs.

### Issue tracking

- [KIWI-2651](https://govukverify.atlassian.net/browse/KIWI-2651)

## Checklists

### Environment variables or secrets

- [ ] Documented in the README
- [ ] Added screenshots/evidence to show higher logs are Pino-style JSON
- [x] Ran cfn-lint on any SAM templates

### Verification

- [x] `yarn lint`
- [x] `yarn test`
- [ ] Confirm deployed logs in higher envs are Pino-style JSON before enabling higher environments

[KIWI-2648]: https://govukverify.atlassian.net/browse/KIWI-2651

[KIWI-2651]: https://govukverify.atlassian.net/browse/KIWI-2651?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ